### PR TITLE
Take advantage of the docker cache for a faster docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,14 @@ RUN add-apt-repository -y ppa:brightbox/ruby-ng && apt-get update && \
 
 RUN apt-get install -y postgresql-client-9.1 && apt-get clean
 
+ADD assets/setup/install /app/setup/install
+ADD assets/.vimrc /root/.vimrc
+ADD assets/.bash_aliases /root/.bashaliases
+RUN chmod 755 /app/setup/install
+RUN /app/setup/install
+
 ADD assets/ /app/
-RUN mv /app/.vimrc /app/.bash_aliases /root/
-RUN chmod 755 /app/init /app/setup/install && /app/setup/install
+RUN chmod 755 /app/init
 
 ADD authorized_keys /root/.ssh/
 RUN chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys && chown root:root -R /root/.ssh

--- a/assets/setup/install
+++ b/assets/setup/install
@@ -37,14 +37,6 @@ else
 fi
 cd /home/git/gitlab
 
-# copy default configurations
-cp /app/setup/config/nginx/gitlab /etc/nginx/sites-available/gitlab
-sudo -u git -H cp config/gitlab.yml.example config/gitlab.yml
-sudo -u git -H cp config/resque.yml.example config/resque.yml
-sudo -u git -H cp config/database.yml.mysql config/database.yml
-sudo -u git -H cp config/unicorn.rb.example config/unicorn.rb
-sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers/rack_attack.rb
-sudo -u git -H cp config/initializers/smtp_settings.rb.sample config/initializers/smtp_settings.rb
 
 # create required tmp and log directories
 sudo -u git -H mkdir -p tmp/pids/ tmp/sockets/


### PR DESCRIPTION
Moved the install script (for both the binary download and the bundle install) to before the ADD assets/ step to take advantage of docker caching system for more detailed explanation see http://ilikestuffblog.com/2014/01/06/how-to-skip-bundle-install-when-deploying-a-rails-app-to-docker/

Also removed the copy default configuration step from the init script (again to make the docker caching system work) as this step is repeated in the init script.
