### PR TITLE
fixed git push fail when GITLAB_PORT is not 80

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -211,7 +211,7 @@ sudo -u git -H sed 's/{{REDIS_HOST}}/'"${REDIS_HOST}"'/' -i /home/git/gitlab/con
 sudo -u git -H sed 's/{{REDIS_PORT}}/'"${REDIS_PORT}"'/' -i /home/git/gitlab/config/resque.yml
 
 # configure gitlab-shell
-sudo -u git -H sed 's/{{GITLAB_HOST}}/'"${GITLAB_HOST}"'/' -i /home/git/gitlab-shell/config.yml
+sudo -u git -H sed 's/{{GITLAB_HOST}}/'"${GITLAB_HOST}:${GITLAB_PORT}"'/' -i /home/git/gitlab-shell/config.yml
 sudo -u git -H sed 's/{{REDIS_HOST}}/'"${REDIS_HOST}"'/' -i /home/git/gitlab-shell/config.yml
 sudo -u git -H sed 's/{{REDIS_PORT}}/'"${REDIS_PORT}"'/' -i /home/git/gitlab-shell/config.yml
 


### PR DESCRIPTION
I map the 80 port to Docker host's 8888 and access gitlab via host ip ,use  params:
`-e "GITLAB_HOST={host ip}" -e "GITLAB_PORT=8888"`
when use `git push`, I got some error:

```
/usr/lib/ruby/2.0.0/net/http.rb:878:in `initialize': Connection refused - connect(2) (Errno::ECONNREFUSED)
    from /usr/lib/ruby/2.0.0/net/http.rb:878:in `open'
    from /usr/lib/ruby/2.0.0/net/http.rb:878:in `block in connect'
    from /usr/lib/ruby/2.0.0/timeout.rb:52:in `timeout'
    from /usr/lib/ruby/2.0.0/net/http.rb:877:in `connect'
    from /usr/lib/ruby/2.0.0/net/http.rb:862:in `do_start'
    from /usr/lib/ruby/2.0.0/net/http.rb:851:in `start'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:75:in `get'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:30:in `allowed?'
    from /home/git/gitlab-shell/lib/gitlab_shell.rb:59:in `validate_access'
    from /home/git/gitlab-shell/lib/gitlab_shell.rb:23:in `exec'
    from /home/git/gitlab-shell/bin/gitlab-shell:16:in `<main>'
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Found `gitlab_url` in  `/home/git/gitlab-shell/config.yml` is `{GITLAB_HOST}` but not `{GITLAB_HOST}:{GITLAB_PORT}`
