### PR TITLE
Remove default nginx configuration

### DIFF
--- a/assets/setup/install
+++ b/assets/setup/install
@@ -79,7 +79,8 @@ chmod +x /etc/init.d/gitlab
 # install logrotate configuration
 cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 
-# copy nginx configuration
+# disable default nginx configuration and enable gitlab's nginx configuration
+rm -f /etc/nginx/sites-enabled/default
 ln -s /etc/nginx/sites-available/gitlab /etc/nginx/sites-enabled/gitlab
 
 # configure supervisord to start nginx


### PR DESCRIPTION
The 'default' nginx config (part of ubuntu) causes ssh pushes to fail.
This is because gitlab-shell makes http://localhost/api/v3/interal/\* calls
and they get routed to 'default' nginx configuration instead of the @gitlab
named location.
