### PR TITLE
Set executable flag on /home/git/data explicitely

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -352,6 +352,10 @@ sudo -u git -H sed 's/{{LDAP_USER_FILTER}}/'"${LDAP_USER_FILTER}"'/' -i /home/gi
 # take ownership of /home/git/data
 chown git:git /home/git/data
 
+# set executable flags on /home/git/data (needed if mounted from a data-only
+# container using --volumes-from)
+chmod +x /home/git/data
+
 # create the repositories directory and make sure it has the right permissions
 sudo -u git -H mkdir -p /home/git/data/repositories/
 sudo chmod ug-s /home/git/data/repositories/


### PR DESCRIPTION
When using a data-only container for the data store and mounting the volumes
from that container using `--volumes-from <data-only-container>`, the volume is
mounted without executable flags. As a result, nginx fails to serve the files
below that directory.

This PR resolves the issue by explicitely setting the executable flags on
`/home/git/data`.
