### PR TITLE
add GITLAB_RELATIVE_URL_ROOT configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
       - [Establishing trust with your server](#establishing-trust-with-your-server)
       - [Installing Trusted SSL Server Certificates](#installing-trusted-ssl-server-certificates)
     - [Putting it all together](#putting-it-all-together)
+    - [Run under sub URI](#run-under-sub-uri)
     - [Available Configuration Parameters](#available-configuration-parameters)
 - [Maintenance](#maintenance)
     - [SSH Login](#ssh-login)
@@ -557,6 +558,19 @@ docker run --name=gitlab -d -h git.local.host \
   sameersbn/gitlab:6.8.2
 ```
 
+### Run under sub URI
+If you like to serve the GitLab under sub URI like http://localhost/gitlab, set GITLAB_RELATIVE_URL_ROOT=/gitlab or anything you like.
+The path should start with slash, and should not have any trailing slashes.
+
+```bash
+docker run --name=gitlab -d \
+  -v /opt/gitlab/data:/home/git/data \
+  -e "GITLAB_RELATIVE_URL_ROOT=/gitlab" \
+  sameersbn/gitlab:6.8.2
+```
+
+When you change the sub URI path, you need to recompile all precompiled assets. This can be done with either deleting tmp/cache/VERSION file under data store, or just `rm -Rf /PATH/TO/DATA_STORE/tmp`. After cleaning up cache files, restart the container.
+
 ### Available Configuration Parameters
 
 Below is the complete list of available options that can be used to customize your gitlab installation.
@@ -572,6 +586,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_BACKUPS**: Setup cron job to automatic backups. Possible values disable, daily or monthly. Disabled by default
 - **GITLAB_BACKUP_EXPIRY**: Configure how long to keep backups before they are deleted. By default when automated backups are disabled backups are kept forever (0 seconds), else the backups expire in 7 days (604800 seconds).
 - **GITLAB_SSH_PORT**: The ssh port number. Defaults to 22.
+- **GITLAB_RELATIVE_URL_ROOT**: The sub URI of the GitLab server, e.g. /gitlab. No default.
 - **GITLAB_HTTPS**: Set to true to enable https support, disabled by default.
 - **GITLAB_HTTPS_ONLY**: Configure access over plain http when GITLAB_HTTPS is enabled. Should be set to false when using a load balancer. Defaults to true.
 - **SSL_SELF_SIGNED**: Set to true when using self signed ssl certificates. false by default.

--- a/assets/config/gitlabhq/gitlab.yml
+++ b/assets/config/gitlabhq/gitlab.yml
@@ -28,7 +28,7 @@ production: &base
     # 4) In ../gitlab-shell/config.yml: gitlab_url: "http://127.0.0.1/gitlab"
     # To update the path, run: sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
     #
-    # relative_url_root: /gitlab
+    # relative_url_root: {{GITLAB_RELATIVE_URL_ROOT}}
 
     # Uncomment and customize if you can't use the default user to run GitLab (default: 'git')
     # user: git

--- a/assets/config/gitlabhq/unicorn.rb
+++ b/assets/config/gitlabhq/unicorn.rb
@@ -17,7 +17,7 @@
 # 4) In ../gitlab-shell/config.yml: gitlab_url: "http://127.0.0.1/gitlab"
 # To update the path, run: sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 #
-# ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+# ENV['RAILS_RELATIVE_URL_ROOT'] = "{{GITLAB_RELATIVE_URL_ROOT}}"
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.

--- a/assets/config/nginx/gitlab
+++ b/assets/config/nginx/gitlab
@@ -23,7 +23,7 @@ server {
   listen *:80 default_server;         # e.g., listen 192.168.1.1:80; In most cases *:80 is a good idea
   server_name {{YOUR_SERVER_FQDN}};     # e.g., server_name source.example.com;
   server_tokens off;     # don't show the version number, a security best practice
-  root /home/git/gitlab/public;
+  root /dev/null;
   
   # Increase this if you want to upload large attachments
   # Or if you want to accept large git objects over http
@@ -33,7 +33,8 @@ server {
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
 
-  location / {
+  location {{GITLAB_RELATIVE_URL_ROOT}}/ {
+    root /home/git/gitlab/public;
     # serve static files from defined root folder;.
     # @gitlab is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @gitlab;
@@ -59,8 +60,8 @@ server {
   }
 
   # Enable gzip compression as per rails guide: http://guides.rubyonrails.org/asset_pipeline.html#gzip-compression
-  location ~ ^/(assets)/  {
-    root /home/git/gitlab/public;
+  location ~ ^{{GITLAB_RELATIVE_URL_ROOT}}/assets/(.*) {
+    alias /home/git/gitlab/public/assets/$1;
     gzip_static on; # to serve pre-gzipped version
     expires max;
     add_header Cache-Control public;

--- a/assets/config/nginx/gitlab.https.permissive
+++ b/assets/config/nginx/gitlab.https.permissive
@@ -23,7 +23,7 @@ server {
   listen *:80 default_server;         # e.g., listen 192.168.1.1:80; In most cases *:80 is a good idea
   server_name {{YOUR_SERVER_FQDN}};     # e.g., server_name source.example.com;
   server_tokens off;     # don't show the version number, a security best practice
-  root /home/git/gitlab/public;
+  root /dev/null;
   
   # Increase this if you want to upload large attachments
   # Or if you want to accept large git objects over http
@@ -33,7 +33,8 @@ server {
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
 
-  location / {
+  location {{GITLAB_RELATIVE_URL_ROOT}}/ {
+    root /home/git/gitlab/public;
     # serve static files from defined root folder;.
     # @gitlab is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @gitlab;
@@ -59,8 +60,8 @@ server {
   }
 
   # Enable gzip compression as per rails guide: http://guides.rubyonrails.org/asset_pipeline.html#gzip-compression
-  location ~ ^/(assets)/  {
-    root /home/git/gitlab/public;
+  location ~ ^{{GITLAB_RELATIVE_URL_ROOT}}/assets/(.*) {
+    alias /home/git/gitlab/public/assets/$1;
     gzip_static on; # to serve pre-gzipped version
     expires max;
     add_header Cache-Control public;
@@ -73,7 +74,7 @@ server {
   listen *:443 default_server ssl;
   server_name {{YOUR_SERVER_FQDN}};
   server_tokens off;
-  root /home/git/gitlab/public;
+  root /dev/null;
 
   ssl on;
   ssl_certificate {{SSL_CERTIFICATE_PATH}};
@@ -97,7 +98,8 @@ server {
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
 
-  location / {
+  location {{GITLAB_RELATIVE_URL_ROOT}}/ {
+    root /home/git/gitlab/public;
     # serve static files from defined root folder;.
     # @gitlab is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @gitlab;
@@ -123,8 +125,8 @@ server {
   }
 
   # Enable gzip compression as per rails guide: http://guides.rubyonrails.org/asset_pipeline.html#gzip-compression
-  location ~ ^/(assets)/  {
-    root /home/git/gitlab/public;
+  location ~ ^{{GITLAB_RELATIVE_URL_ROOT}}/assets/(.*) {
+    alias /home/git/gitlab/public/assets/$1;
     gzip_static on; # to serve pre-gzipped version
     expires max;
     add_header Cache-Control public;

--- a/assets/config/nginx/gitlab.https.strict
+++ b/assets/config/nginx/gitlab.https.strict
@@ -30,7 +30,7 @@ server {
   listen *:443 default_server ssl;
   server_name {{YOUR_SERVER_FQDN}};
   server_tokens off;
-  root /home/git/gitlab/public;
+  root /dev/null;
 
   ssl on;
   ssl_certificate {{SSL_CERTIFICATE_PATH}};
@@ -54,7 +54,8 @@ server {
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
 
-  location / {
+  location {{GITLAB_RELATIVE_URL_ROOT}}/ {
+    root /home/git/gitlab/public;
     # serve static files from defined root folder;.
     # @gitlab is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @gitlab;
@@ -80,8 +81,8 @@ server {
   }
 
   # Enable gzip compression as per rails guide: http://guides.rubyonrails.org/asset_pipeline.html#gzip-compression
-  location ~ ^/(assets)/  {
-    root /home/git/gitlab/public;
+  location ~ ^{{GITLAB_RELATIVE_URL_ROOT}}/assets/(.*) {
+    alias /home/git/gitlab/public/assets/$1;
     gzip_static on; # to serve pre-gzipped version
     expires max;
     add_header Cache-Control public;

--- a/assets/init
+++ b/assets/init
@@ -13,6 +13,7 @@ GITLAB_SIGNUP=${GITLAB_SIGNUP:-false}
 GITLAB_SIGNIN=${GITLAB_SIGNIN:-true}
 GITLAB_PROJECTS_LIMIT=${GITLAB_PROJECTS_LIMIT:-100}
 GITLAB_PROJECTS_VISIBILITY=${GITLAB_PROJECTS_VISIBILITY:-private}
+GITLAB_RELATIVE_URL_ROOT=${GITLAB_RELATIVE_URL_ROOT:-}
 
 SSL_SELF_SIGNED=${SSL_SELF_SIGNED:-false}
 SSL_CERTIFICATE_PATH=${SSL_CERTIFICATE_PATH:-/home/git/data/certs/gitlab.crt}
@@ -110,11 +111,11 @@ fi
 
 case "${GITLAB_HTTPS}" in
 	true)
-		GITLAB_URL="https://${GITLAB_HOST}${GITLAB_PORT:+:$GITLAB_PORT}/"
+		GITLAB_URL="https://${GITLAB_HOST}${GITLAB_PORT:+:$GITLAB_PORT}${GITLAB_RELATIVE_URL_ROOT}/"
 		GITLAB_PORT=${GITLAB_PORT:-443}
 		;;
 	*)
-		GITLAB_URL="http://${GITLAB_HOST}${GITLAB_PORT:+:$GITLAB_PORT}/"
+		GITLAB_URL="http://${GITLAB_HOST}${GITLAB_PORT:+:$GITLAB_PORT}${GITLAB_RELATIVE_URL_ROOT}/"
 		GITLAB_PORT=${GITLAB_PORT:-80}
 		;;
 esac
@@ -197,6 +198,10 @@ sed 's,{{SSL_CERTIFICATE_PATH}},'"${SSL_CERTIFICATE_PATH}"',' -i /etc/nginx/site
 sed 's,{{SSL_KEY_PATH}},'"${SSL_KEY_PATH}"',' -i /etc/nginx/sites-available/gitlab
 sed 's,{{SSL_DHPARAM_PATH}},'"${SSL_DHPARAM_PATH}"',' -i /etc/nginx/sites-available/gitlab
 sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/g' -i /etc/nginx/sites-available/gitlab
+
+# configure relative_url_root
+sed 's,{{GITLAB_RELATIVE_URL_ROOT}},'${GITLAB_RELATIVE_URL_ROOT}',g' -i /etc/nginx/sites-available/gitlab
+
 supervisorctl start nginx
 
 echo "Updating CA certificates..."
@@ -317,7 +322,7 @@ case "${GITLAB_HTTPS}" in
 					true)
 						# we are using self signed certificates, talk to gitlab over https on localhost
 						# this will make sure the api access works when the default https port is not used.
-						sed -i 's,#{config.gitlab_url}/api/v3/internal,https://localhost/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
+						sed -i 's,#{config.gitlab_url}/api/v3/internal,https://localhost'${GITLAB_RELATIVE_URL_ROOT}'/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
 						;;
 					*)
 						# signed https certificates are in use, talk to gitlab using the default gitlab_url.
@@ -329,13 +334,13 @@ case "${GITLAB_HTTPS}" in
 			*)
 				# we are not using https only mode, talk to gitlab over plain http on localhost
 				# using http when available will keep things fast.
-				sed -i 's,#{config.gitlab_url}/api/v3/internal,http://localhost/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
+				sed -i 's,#{config.gitlab_url}/api/v3/internal,http://localhost'${GITLAB_RELATIVE_URL_ROOT}'/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
 				;;
 		esac
 		;;
 	*)
 		# ssl is not being used, talk to gitlab over plain http
-		sed -i 's,#{config.gitlab_url}/api/v3/internal,http://localhost/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
+		sed -i 's,#{config.gitlab_url}/api/v3/internal,http://localhost'${GITLAB_RELATIVE_URL_ROOT}'/api/v3/internal,' -i /home/git/gitlab-shell/lib/gitlab_net.rb
 		;;
 esac
 
@@ -378,6 +383,13 @@ sudo -u git -H sed 's/{{LDAP_PASS}}/'"${LDAP_PASS}"'/' -i /home/git/gitlab/confi
 sudo -u git -H sed 's/{{LDAP_ALLOW_USERNAME_OR_EMAIL_LOGIN}}/'"${LDAP_ALLOW_USERNAME_OR_EMAIL_LOGIN}"'/' -i /home/git/gitlab/config/gitlab.yml
 sudo -u git -H sed 's/{{LDAP_BASE}}/'"${LDAP_BASE}"'/' -i /home/git/gitlab/config/gitlab.yml
 sudo -u git -H sed 's/{{LDAP_USER_FILTER}}/'"${LDAP_USER_FILTER}"'/' -i /home/git/gitlab/config/gitlab.yml
+
+# configure relative_url_root
+if [ ${GITLAB_RELATIVE_URL_ROOT} ]; then
+	sudo -u git -H sed 's,# config.relative_url_root = "/gitlab",config.relative_url_root = "'${GITLAB_RELATIVE_URL_ROOT}'",' -i /home/git/gitlab/config/application.rb
+	sudo -u git -H sed 's,# relative_url_root: {{GITLAB_RELATIVE_URL_ROOT}},relative_url_root: '${GITLAB_RELATIVE_URL_ROOT}',' -i /home/git/gitlab/config/gitlab.yml
+	sudo -u git -H sed "s,# ENV\['RAILS_RELATIVE_URL_ROOT'\] = \"{{GITLAB_RELATIVE_URL_ROOT}}\",ENV\['RAILS_RELATIVE_URL_ROOT'\] = \"${GITLAB_RELATIVE_URL_ROOT}\"," -i /home/git/gitlab/config/unicorn.rb
+fi
 
 # take ownership of /home/git/data
 chown git:git /home/git/data


### PR DESCRIPTION
I've added support for serving Gitlab under sub URI like http://localhost/gitlab.
