### PR TITLE
Enable SPDY support

### DIFF
--- a/assets/config/nginx/gitlab.https.permissive
+++ b/assets/config/nginx/gitlab.https.permissive
@@ -111,7 +111,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl spdy;
   ## Replace git.example.com with your FQDN.
   server_name {{YOUR_SERVER_FQDN}};
   server_tokens off;

--- a/assets/config/nginx/gitlab.https.strict
+++ b/assets/config/nginx/gitlab.https.strict
@@ -72,7 +72,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl spdy;
   ## Replace git.example.com with your FQDN.
   server_name {{YOUR_SERVER_FQDN}};
   server_tokens off;


### PR DESCRIPTION
nginx comes with SPDY basically for free

But there's one caveat: since Ubuntu 14.x comes with nginx 1.4.x it only implements SPDY draft 2 (which is deprecated by now). Nevertheless if Ubuntu decides to ship a newer version of nginx (1.5.10 or newer) this automatically becomes draft 3 support.
