### PR TITLE
Update README to reference psql in postgresql container

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Now, lets login to the postgresql server and create a user and database for the 
 
 ```bash
 POSTGRESQL_IP=$(docker inspect postgresql | grep IPAddres | awk -F'"' '{print $4}')
-psql -U postgres -h ${POSTGRESQL_IP}
+docker run -it --rm sameersbn/postgresql:latest psql -U postgres -h ${POSTGRESQL_IP}
 ```
 
 ```sql


### PR DESCRIPTION
I don't have psql installed on my host, and since it's already provided in the postgresql container, I modified the psql request to reference that one.
