### PR TITLE
update : index.html : Default user name

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,7 @@ sameersbn/gitlab:latest
 <p>Point your browser to <code>http://localhost:10080</code> and login using the default username and password:</p>
 
 <ul>
-<li>username: <a href="mailto:admin@local.host">admin@local.host</a>
-</li>
+<li>username: root</li>
 <li>password: 5iveL!fe</li>
 </ul><p>* <em>download and start up times not included</em></p>
       </section>


### PR DESCRIPTION
The default username is `root`, as of [GitLab's README](https://github.com/gitlabhq/gitlabhq#run-in-production-mode).

Just tested and stumbled across this while fireing up the oneliner from [the page](http://www.damagehead.com/docker-gitlab/).

Thanks for making this possible, though.
