### PR TITLE
introduced the variable GITLAB_BACKUP_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_USERNAME_CHANGE**: Enable or disable ability for users to change their username. Defaults is `true`.
 - **GITLAB_PROJECTS_VISIBILITY**: Set default projects visibility level. Possible values `public`, `private` and `internal`. Defaults to `private`.
 - **GITLAB_RESTRICTED_VISIBILITY**: Comma seperated list of visibility levels to restrict non-admin users to set. Possible visibility options are `public`, `private` and `internal`.
+- **GITLAB_BACKUP_DIR**: The backup folder in the container. Defaults to `/home/git/data/backups`
 - **GITLAB_BACKUPS**: Setup cron job to automatic backups. Possible values `disable`, `daily` or `monthly`. Disabled by default
 - **GITLAB_BACKUP_EXPIRY**: Configure how long (in seconds) to keep backups before they are deleted. By default when automated backups are disabled backups are kept forever (0 seconds), else the backups expire in 7 days (604800 seconds).
 - **GITLAB_SSH_HOST**: The ssh host. Defaults to **GITLAB_HOST**.
@@ -818,7 +819,7 @@ docker run --name=gitlab -it --rm [OPTIONS] \
   sameersbn/gitlab:7.2.1-1 app:rake gitlab:backup:create
 ```
 
-A backup will be created in the backups folder of the [Data Store](#data-store)
+A backup will be created in the backups folder of the [Data Store](#data-store). You can change that behavior by setting your own path within the container. To do so you have to pass the argument `-e "GITLAB_BACKUP_DIR:/path/to/backups"` to the docker run command.
 
 ## Restoring Backups
 

--- a/assets/config/gitlabhq/gitlab.yml
+++ b/assets/config/gitlabhq/gitlab.yml
@@ -202,7 +202,7 @@ production: &base
 
   ## Backup settings
   backup:
-    path: "{{GITLAB_DATA_DIR}}/backups"   # Relative paths are relative to Rails.root (default: tmp/backups/)
+    path: "{{GITLAB_BACKUP_DIR}}"   # Relative paths are relative to Rails.root (default: tmp/backups/)
     keep_time: {{GITLAB_BACKUP_EXPIRY}}   # default: 0 (forever) (in seconds)
 
   ## GitLab Shell settings

--- a/assets/init
+++ b/assets/init
@@ -3,6 +3,7 @@ set -e
 
 GITLAB_INSTALL_DIR="/home/git/gitlab"
 GITLAB_DATA_DIR="/home/git/data"
+GITLAB_BACKUP_DIR="${GITLAB_BACKUP_DIR:-$GITLAB_DATA_DIR/backups}"
 GITLAB_SHELL_INSTALL_DIR="/home/git/gitlab-shell"
 
 SETUP_DIR="/app/setup"
@@ -271,6 +272,7 @@ sudo -u git -H git config --global core.autocrlf input
 
 # configure application paths
 sudo -u git -H sed 's,{{GITLAB_DATA_DIR}},'"${GITLAB_DATA_DIR}"',g' -i config/gitlab.yml
+sudo -u git -H sed 's,{{GITLAB_BACKUP_DIR}},'"${GITLAB_BACKUP_DIR}"',g' -i config/gitlab.yml
 sudo -u git -H sed 's,{{GITLAB_SHELL_INSTALL_DIR}},'"${GITLAB_SHELL_INSTALL_DIR}"',g' -i config/gitlab.yml
 
 # configure gitlab
@@ -330,6 +332,7 @@ sudo -u git -H sed 's/{{REDIS_PORT}}/'"${REDIS_PORT}"'/g' -i config/resque.yml
 # configure gitlab-shell
 sed 's,{{GITLAB_RELATIVE_URL_ROOT}},'"${GITLAB_RELATIVE_URL_ROOT}"',' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
 sudo -u git -H sed 's,{{GITLAB_DATA_DIR}},'"${GITLAB_DATA_DIR}"',g' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
+sudo -u git -H sed 's,{{GITLAB_BACKUP_DIR}},'"${GITLAB_BACKUP_DIR}"',g' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
 sudo -u git -H sed 's/{{SSL_SELF_SIGNED}}/'"${SSL_SELF_SIGNED}"'/' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
 sudo -u git -H sed 's/{{REDIS_HOST}}/'"${REDIS_HOST}"'/' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
 sudo -u git -H sed 's/{{REDIS_PORT}}/'"${REDIS_PORT}"'/' -i ${GITLAB_SHELL_INSTALL_DIR}/config.yml
@@ -492,8 +495,8 @@ chown git:git ${GITLAB_DATA_DIR}/gitlab-satellites
 rm -rf ${GITLAB_DATA_DIR}/cache
 
 # create the backups directory
-sudo -u git -H mkdir -p ${GITLAB_DATA_DIR}/backups/
-chown git:git ${GITLAB_DATA_DIR}/backups/
+sudo -u git -H mkdir -p ${GITLAB_BACKUP_DIR}
+chown git:git ${GITLAB_BACKUP_DIR}
 
 # create the uploads directory
 sudo -u git -H mkdir -p ${GITLAB_DATA_DIR}/uploads/
@@ -602,19 +605,19 @@ appRake () {
 
   if [ "$1" == "gitlab:backup:restore" ]; then
     # user needs to select the backup to restore
-    nBackups=$(ls ${GITLAB_DATA_DIR}/backups/*_gitlab_backup.tar | wc -l)
+    nBackups=$(ls ${GITLAB_BACKUP_DIR}/*_gitlab_backup.tar | wc -l)
     if [ $nBackups -eq 0 ]; then
       echo "No backup present. Cannot continue restore process.".
       return 1
     fi
 
-    for b in `ls ${GITLAB_DATA_DIR}/backups/ | sort -r`
+    for b in `ls ${GITLAB_BACKUP_DIR} | sort -r`
     do
       echo " ├ $b"
     done
     read -p "Select a backup to restore: " file
 
-    if [ ! -f "${GITLAB_DATA_DIR}/backups/${file}" ]; then
+    if [ ! -f "${GITLAB_BACKUP_DIR}/${file}" ]; then
       echo "Specified backup does not exist. Aborting..."
       return 1
     fi


### PR DESCRIPTION
... with whom users can determine the containers backup location. this adresses an issue of docker, where docker gets in trouble with mounting subdirectorys of already mounted directorys. thus the backup directory could be set to a location outside the GITLAB_DATA_DIR.
