### PR TITLE
Add host option to database status check

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -563,7 +563,7 @@ appStart () {
   # for the database server to come online.
   case "${DB_TYPE}" in
     mysql)
-      prog="mysqladmin -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} status"
+      prog="mysqladmin -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} -h $DB_HOST status"
       ;;
     postgres)
       prog=$(find /usr/lib/postgresql/ -name pg_isready)


### PR DESCRIPTION
With the new method of checking the status/state of the database to determine if the setup rake process needs to be run, it looks like the -h option was missed from the mysqladmin command.

At this point in the script $DB_HOST is either defined by the environment variable or defaulted to localhost.
