### PR TITLE
fix the password parameter to mysql commands

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -279,7 +279,7 @@ if [ "${DB_HOST}" == "localhost" ]; then
 
   # wait for mysql server to start (max 120 seconds)
   timeout=120
-  while ! mysqladmin -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} status >/dev/null 2>&1
+  while ! mysqladmin -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} status >/dev/null 2>&1
   do
     timeout=$(expr $timeout - 1)
     if [ $timeout -eq 0 ]; then
@@ -289,9 +289,9 @@ if [ "${DB_HOST}" == "localhost" ]; then
     sleep 1
   done
 
-  if ! mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} -e "USE ${DB_NAME};" >/dev/null 2>&1; then
-    mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` DEFAULT CHARACTER SET \`utf8\` COLLATE \`utf8_unicode_ci\`;"
-    mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} -e "GRANT SELECT, LOCK TABLES, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON \`${DB_NAME}\`.* TO 'root'@'localhost';"
+  if ! mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} -e "USE ${DB_NAME};" >/dev/null 2>&1; then
+    mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` DEFAULT CHARACTER SET \`utf8\` COLLATE \`utf8_unicode_ci\`;"
+    mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} -e "GRANT SELECT, LOCK TABLES, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON \`${DB_NAME}\`.* TO 'root'@'localhost';"
   fi
 fi
 
@@ -563,7 +563,7 @@ appStart () {
   # for the database server to come online.
   case "${DB_TYPE}" in
     mysql)
-      prog="mysqladmin -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} status"
+      prog="mysqladmin -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} status"
       ;;
     postgres)
       prog=$(find /usr/lib/postgresql/ -name pg_isready)
@@ -586,7 +586,7 @@ appStart () {
   case "${DB_TYPE}" in
     mysql)
       QUERY="SELECT count(*) FROM information_schema.tables WHERE table_schema = '${DB_NAME}';"
-      COUNT=$(mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p $DB_PASS} -ss -e "${QUERY}")
+      COUNT=$(mysql -h ${DB_HOST} -u ${DB_USER} ${DB_PASS:+-p$DB_PASS} -ss -e "${QUERY}")
       ;;
     postgres)
       QUERY="SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';"


### PR DESCRIPTION
mysql -p parameter does not take space afterwards (strange format: http://www.jacobtomlinson.co.uk/2013/05/31/why-is-there-no-space-in-the-mysql-password-parameter/)
