### PR TITLE
add option to disable users creating groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_SIGNIN**: If set to `false`, standard login form won't be shown on the sign-in page. Default is `true`.
 - **GITLAB_PROJECTS_LIMIT**: Set default projects limit. Defaults to `100`.
 - **GITLAB_USERNAME_CHANGE**: Enable or disable ability for users to change their username. Defaults is `true`.
+- **GITLAB_CREATE_GROUP**: Enable or disable ability for users to create groups. Defaults is `true`.
 - **GITLAB_PROJECTS_VISIBILITY**: Set default projects visibility level. Possible values `public`, `private` and `internal`. Defaults to `private`.
 - **GITLAB_RESTRICTED_VISIBILITY**: Comma seperated list of visibility levels to restrict non-admin users to set. Possible visibility options are `public`, `private` and `internal`.
 - **GITLAB_WEBHOOK_TIMEOUT**: Sets the timeout for webhooks. Defaults to `10` seconds.

--- a/assets/config/gitlabhq/gitlab.yml
+++ b/assets/config/gitlabhq/gitlab.yml
@@ -41,7 +41,7 @@ production: &base
 
     ## User settings
     default_projects_limit: {{GITLAB_PROJECTS_LIMIT}}
-    # default_can_create_group: false  # default: true
+    default_can_create_group: {{GITLAB_CREATE_GROUP}} # default: true - User can create groups
     username_changing_enabled: {{GITLAB_USERNAME_CHANGE}} # default: true - User can change her username/namespace
     ## Default theme
     ##   BASIC  = 1

--- a/assets/init
+++ b/assets/init
@@ -23,6 +23,7 @@ GITLAB_SIGNUP=${GITLAB_SIGNUP:-false}
 GITLAB_SIGNIN=${GITLAB_SIGNIN:-true}
 GITLAB_PROJECTS_LIMIT=${GITLAB_PROJECTS_LIMIT:-100}
 GITLAB_USERNAME_CHANGE=${GITLAB_USERNAME_CHANGE:-true}
+GITLAB_CREATE_GROUP=${GITLAB_CREATE_GROUP:-true}
 GITLAB_PROJECTS_VISIBILITY=${GITLAB_PROJECTS_VISIBILITY:-private}
 GITLAB_RELATIVE_URL_ROOT=${GITLAB_RELATIVE_URL_ROOT:-}
 GITLAB_RESTRICTED_VISIBILITY=${GITLAB_RESTRICTED_VISIBILITY:-}
@@ -359,6 +360,9 @@ sudo -u git -H sed 's/{{GITLAB_PROJECTS_LIMIT}}/'"${GITLAB_PROJECTS_LIMIT}"'/' -
 
 # configure gitlab username_changing_enabled
 sudo -u git -H sed 's/{{GITLAB_USERNAME_CHANGE}}/'"${GITLAB_USERNAME_CHANGE}"'/' -i config/gitlab.yml
+
+# configure gitlab default_can_create_group
+sudo -u git -H sed 's/{{GITLAB_CREATE_GROUP}}/'"${GITLAB_CREATE_GROUP}"'/' -i config/gitlab.yml
 
 # configure gitlab default visibility_level
 sudo -u git -H sed 's/{{GITLAB_PROJECTS_VISIBILITY}}/'"${GITLAB_PROJECTS_VISIBILITY}"'/' -i config/gitlab.yml


### PR DESCRIPTION
Add support for setting the option `default_can_create_group`.  This is to stop users from being able to create groups by default.
