### PR TITLE
Add configuration for sendmail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E1DF1F24 \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && apt-get update \
- && apt-get install -y supervisor logrotate locales \
+ && apt-get install -y supervisor logrotate locales postfix \
       nginx openssh-server mysql-client postgresql-client redis-tools \
       git-core ruby2.1 python2.7 python-docutils \
       libmysqlclient18 libpq5 zlib1g libyaml-0-2 libssl1.0.0 \

--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Below is the complete list of available options that can be used to customize yo
 - **SMTP_STARTTLS**: Enable STARTTLS. Defaults to `true`.
 - **SMTP_OPENSSL_VERIFY_MODE**: SMTP openssl verification mode. Accepted values are `none`, `peer`, `client_once` and `fail_if_no_peer_cert`. SSL certificate verification is performed by default.
 - **SMTP_AUTHENTICATION**: Specify the SMTP authentication method. Defaults to `login` if `SMTP_USER` is set.
+- **SENDMAIL_ENABLED**: Enable mail delivery via `sendmail`. Defaults to `false`. Switched to `false` if `SMTP_ENABLED` is `true`.
 - **LDAP_ENABLED**: Enable LDAP. Defaults to `false`
 - **LDAP_HOST**: LDAP Host
 - **LDAP_PORT**: LDAP Port. Defaults to `636`

--- a/assets/config/gitlabhq/sendmail_settings.rb
+++ b/assets/config/gitlabhq/sendmail_settings.rb
@@ -1,0 +1,8 @@
+# To enable smtp email delivery for your GitLab instance do next:
+# 1. Rename this file to smtp_settings.rb
+# 2. Edit settings inside this file
+# 3. Restart GitLab instance
+#
+if Rails.env.production?
+  Gitlab::Application.config.action_mailer.delivery_method = :sendmail
+end

--- a/assets/config/postfix/main.cf
+++ b/assets/config/postfix/main.cf
@@ -1,0 +1,10 @@
+mydomain = {{GITLAB_HOST}}
+myorigin = $mydomain
+mynetworks = 127.0.0.0/8
+relay_domains =
+relayhost =
+mydestination =
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = all
+inet_protocols = all

--- a/assets/init
+++ b/assets/init
@@ -85,6 +85,9 @@ fi
 SMTP_ENABLED=${SMTP_ENABLED:-false}
 GITLAB_EMAIL_ENABLED=${GITLAB_EMAIL_ENABLED:-$SMTP_ENABLED}
 
+SENDMAIL_ENABLED=${SENDMAIL_ENABLED:-false}
+[ "$SMTP_ENABLED" == "true" ] && SENDMAIL_ENABLED=false
+
 LDAP_ENABLED=${LDAP_ENABLED:-false}
 LDAP_HOST=${LDAP_HOST:-}
 LDAP_PORT=${LDAP_PORT:-636}
@@ -338,6 +341,9 @@ sudo -u git -H cp ${SYSCONF_TEMPLATES_DIR}/gitlabhq/rack_attack.rb    config/ini
 [ "${SMTP_ENABLED}" == "true" ] && \
 sudo -u git -H cp ${SYSCONF_TEMPLATES_DIR}/gitlabhq/smtp_settings.rb  config/initializers/smtp_settings.rb
 
+[ "${SENDMAIL_ENABLED}" == "true" ] && \
+sudo -u git -H cp ${SYSCONF_TEMPLATES_DIR}/gitlabhq/sendmail_settings.rb config/initializers/smtp_settings.rb
+
 # override default configuration templates with user templates
 case "${GITLAB_HTTPS}" in
   true)
@@ -356,7 +362,7 @@ esac
 [ -f ${USERCONF_TEMPLATES_DIR}/gitlabhq/database.yml ]     && sudo -u git -H cp ${USERCONF_TEMPLATES_DIR}/gitlabhq/database.yml     config/database.yml
 [ -f ${USERCONF_TEMPLATES_DIR}/gitlabhq/unicorn.rb ]       && sudo -u git -H cp ${USERCONF_TEMPLATES_DIR}/gitlabhq/unicorn.rb       config/unicorn.rb
 [ -f ${USERCONF_TEMPLATES_DIR}/gitlabhq/rack_attack.rb ]   && sudo -u git -H cp ${USERCONF_TEMPLATES_DIR}/gitlabhq/rack_attack.rb   config/initializers/rack_attack.rb
-[ "${SMTP_ENABLED}" == "true" ] && \
+[ "${SMTP_ENABLED}" == "true" ] || [ "${SENDMAIL_ENABLED}" == "true" ] && \
 [ -f ${USERCONF_TEMPLATES_DIR}/gitlabhq/smtp_settings.rb ] && sudo -u git -H cp ${USERCONF_TEMPLATES_DIR}/gitlabhq/smtp_settings.rb config/initializers/smtp_settings.rb
 
 if [ -f "${SSL_CERTIFICATE_PATH}" -o -f "${CA_CERTIFICATES_PATH}" ]; then
@@ -498,6 +504,13 @@ if [ "${SMTP_ENABLED}" == "true" ]; then
     "") sudo -u git -H sed '/{{SMTP_AUTHENTICATION}}/d' -i config/initializers/smtp_settings.rb ;;
     *) sudo -u git -H sed 's/{{SMTP_AUTHENTICATION}}/'"${SMTP_AUTHENTICATION}"'/' -i config/initializers/smtp_settings.rb ;;
   esac
+fi
+
+if [ "${SENDMAIL_ENABLED}" == "true" ]; then
+  # configure postfix
+  sudo cp ${SYSCONF_TEMPLATES_DIR}/postfix/main.cf /etc/postfix/main.cf
+  sudo sed 's/{{GITLAB_HOST}}/'"${GITLAB_HOST}"'/' -i /etc/postfix/main.cf
+  sudo service postfix start
 fi
 
 # apply LDAP configuration


### PR DESCRIPTION
If `SENDMAIL_ENABLED` is set to `true` then postfix will be started and Gitlab will be configured to use sendmail. If both `SENDMAIL_ENABLED` and `SMTP_ENABLED` are `true` then the sendmail feature is disabled. The configuration for postfix is simple; it is setup as a relay.

Postfix forks into the background and as a result cannot be started under supervisord. See the following link for more background information:

http://goo.gl/F4neAQ

Closes sameersbn/docker-gitlab#208

I opted to use postfix over sendmail because postfix is the default MTA on Ubuntu and is significantly easier to configure.