### PR TITLE
Disable IPv6 support for Nginx

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -603,6 +603,11 @@ else
   sudo -u git -H sed '/{{GITLAB_RELATIVE_URL_ROOT}}/d' -i config/unicorn.rb
 fi
 
+# disable ipv6 support
+if [ ! -f /proc/net/if_inet6 ]; then
+  sed -e '/listen \[::\]:80/ s/^#*/#/' -i /etc/nginx/sites-enabled/gitlab
+fi
+
 # fix permission and ownership of ${GITLAB_DATA_DIR}
 chmod 755 ${GITLAB_DATA_DIR}
 chown git:git ${GITLAB_DATA_DIR}


### PR DESCRIPTION
On some servers, IPv6 is not available, so Nginx can't listen on  [::]:80 

```
2014/12/19 07:18:32 [emerg] 484#0: socket() [::]:80 failed (97: Address family not supported by protocol)
```

I removed the line and the container start successfully.
