### PR TITLE
support linking with official postgres image

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -138,6 +138,11 @@ elif [ -n "${POSTGRESQL_PORT_5432_TCP_ADDR}" ]; then
   DB_HOST=${DB_HOST:-${POSTGRESQL_PORT_5432_TCP_ADDR}}
   DB_PORT=${DB_PORT:-${POSTGRESQL_PORT_5432_TCP_PORT}}
 
+  # support for linked official postgres image
+  DB_USER=${DB_USER:-${POSTGRESQL_ENV_POSTGRES_USER}}
+  DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_POSTGRES_PASS}}
+  DB_NAME=${DB_NAME:-${DB_USER}}
+
   # support for linked sameersbn/postgresql image
   DB_USER=${DB_USER:-${POSTGRESQL_ENV_DB_USER}}
   DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_DB_PASS}}


### PR DESCRIPTION
The official postgres image uses `POSTGRES` environ vars and names the database the same as the user.

See https://github.com/docker-library/postgres/blob/51e5166d69320581cb707d6fb102d3ba04803400/docker-entrypoint.sh#L37