### PR TITLE
Allow setting of the root password

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_HOST**: The hostname of the GitLab server. Defaults to `localhost`
 - **GITLAB_PORT**: The port of the GitLab server. Defaults to `80` for plain http and `443` when https is enabled.
 - **GITLAB_TIMEZONE**: Configure the timezone for the gitlab application. This configuration does not effect cron jobs. Defaults to `UTC`.
+- **GITLAB_ROOT_PASSWORD**: The password for the root user. Defaults to `5iveL!fe`.
 - **GITLAB_EMAIL**: The email address for the GitLab server.  Defaults to `example@example.com`.
 - **GITLAB_EMAIL_ENABLED**: Enable or disable gitlab mailer. Defaults to the `SMTP_ENABLED` configuration.
 - **GITLAB_USERNAME_CHANGE**: Enable or disable ability for users to change their username. Defaults is `true`.

--- a/assets/init
+++ b/assets/init
@@ -731,7 +731,7 @@ appStart () {
   esac
   if [ -z "${COUNT}" -o ${COUNT} -eq 0 ]; then
     echo "Setting up GitLab for firstrun. Please be patient, this could take a while..."
-    sudo -u git -H force=yes bundle exec rake gitlab:setup RAILS_ENV=production >/dev/null
+    sudo -u git -H force=yes bundle exec rake gitlab:setup RAILS_ENV=production ${GITLAB_ROOT_PASSWORD:+GITLAB_ROOT_PASSWORD=$GITLAB_ROOT_PASSWORD} >/dev/null
   fi
 
   # migrate database and compile the assets if the gitlab version or relative_url has changed.


### PR DESCRIPTION
Hey,

This patch exposes an environment variable that can be used to configure a default root password.

The only documentation I have seen for this is here https://github.com/gitlabhq/gitlabhq/blob/master/doc/install/installation.md#initialize-database-and-activate-advanced-features

Cheers,
Russell