### PR TITLE
Updated README in order to fix libdevmapper.so issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ docker run --name='gitlab' -it --rm \
 -p 10022:22 -p 10080:80 \
 -v /var/run/docker.sock:/run/docker.sock \
 -v $(which docker):/bin/docker \
+-v /usr/lib/libdevmapper.so.1.02:/usr/lib/libdevmapper.so.1.02 \
 sameersbn/gitlab:7.8.4
 ```
 


### PR DESCRIPTION
Added libdevmapper.so mapping which seems to fix the error "docker: error while loading shared libraries: libdevmapper.so.1.02: cannot open shared object file: No such file or directory" which appears in coreos and other distributions as of the latest docker release.

Feel free to test with other distributions. The error seems to be common.