### PR TITLE
add AWS_BACKUPS to configure automatic backups to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,11 @@ Below is the complete list of available options that can be used to customize yo
 - **GOOGLE_ANALYTICS_ID**: Google Analytics ID. No defaults.
 - **PIWIK_URL**: Sets the Piwik URL. No defaults.
 - **PIWIK_SITE_ID**: Sets the Piwik site ID. No defaults.
+- **AWS_BACKUPS**: Enables automatic uploads to an Amazon S3 instance. Defaults to `false`.
+- **AWS_BACKUP_REGION**: AWS region. No defaults.
+- **AWS_BACKUP_ACCESS_KEY_ID**: AWS access key id. No defaults.
+- **AWS_BACKUP_SECRET_ACCESS_KEY**: AWS secret access key. No defaults.
+- **AWS_BACKUP_BUCKET**: AWS bucket for backup uploads. No defaults.
 
 # Maintenance
 
@@ -843,6 +848,14 @@ The image can be configured to automatically take backups on a daily, weekly or 
 Daily backups are created at `GITLAB_BACKUP_TIME` which defaults to `04:00` everyday. Weekly backups are created every Sunday at the same time as the daily backups. Monthly backups are created on the 1st of every month at the same time as the daily backups.
 
 By default, when automated backups are enabled, backups are held for a period of 7 days. While when automated backups are disabled, the backups are held for an infinite period of time. This can behavior can be configured via the `GITLAB_BACKUP_EXPIRY` option.
+
+## Automatic Amazon Web Services (AWS) S3 Uploads
+
+The image can be configured to automatically upload the backups to an AWS S3 bucket. To enable automatic AWS backups first add `-e 'AWS_BACKUPS=true'` to the docker run command. In addition `AWS_BACKUP_REGION` and `AWS_BACKUP_BUCKET` must be properly configured to point to the desired AWS location. Finally an IAM user must be configured with appropriate access permission and their AWS keys exposed through `AWS_BACKUP_ACCESS_KEY_ID` and `AWS_BACKUP_SECRET_ACCESS_KEY`.
+
+More details about the appropriate IAM user properties can found on [doc.gitlab.com](http://doc.gitlab.com/ce/raketasks/backup_restore.html#upload-backups-to-remote-cloud-storage)
+
+AWS uploads are performed alongside normal backups, both through the appropriate `app:rake` command and when an automatic backup is performed.
 
 ## Shell Access
 

--- a/assets/config/gitlabhq/gitlab.yml
+++ b/assets/config/gitlabhq/gitlab.yml
@@ -225,15 +225,15 @@ production: &base
   backup:
     path: "{{GITLAB_BACKUP_DIR}}"   # Relative paths are relative to Rails.root (default: tmp/backups/)
     keep_time: {{GITLAB_BACKUP_EXPIRY}}   # default: 0 (forever) (in seconds)
-    # upload:
-    #   # Fog storage connection settings, see http://fog.io/storage/ .
-    #   connection:
-    #     provider: AWS
-    #     region: eu-west-1
-    #     aws_access_key_id: AKIAKIAKI
-    #     aws_secret_access_key: 'secret123'
-    #   # The remote 'directory' to store your backups. For S3, this would be the bucket name.
-    #   remote_directory: 'my.s3.bucket'
+    upload:
+      # Fog storage connection settings, see http://fog.io/storage/ .
+      connection:
+        provider: AWS
+        region: {{AWS_BACKUP_REGION}}
+        aws_access_key_id: {{AWS_BACKUP_ACCESS_KEY_ID}}
+        aws_secret_access_key: '{{AWS_BACKUP_SECRET_ACCESS_KEY}}'
+      # The remote 'directory' to store your backups. For S3, this would be the bucket name.
+      remote_directory: '{{AWS_BACKUP_BUCKET}}'
 
   ## GitLab Shell settings
   gitlab_shell:

--- a/assets/init
+++ b/assets/init
@@ -517,6 +517,10 @@ sudo -u git -H sed 's/{{LDAP_USER_FILTER}}/'"${LDAP_USER_FILTER}"'/' -i config/g
 # apply aws s3 backup configuration
 case "${AWS_BACKUPS}" in
   true)
+    if [ -z "${AWS_BACKUP_REGION}" -o -z "${AWS_BACKUP_ACCESS_KEY_ID}" -o -z "${AWS_BACKUP_SECRET_ACCESS_KEY}" -o -z "${AWS_BACKUP_BUCKET}" ]; then
+      printf "\nMissing AWS options. Aborting...\n"
+      exit 1
+    fi
     sudo -u git -H sed 's/{{AWS_BACKUP_REGION}}/'"${AWS_BACKUP_REGION}"'/' -i config/gitlab.yml
     sudo -u git -H sed 's/{{AWS_BACKUP_ACCESS_KEY_ID}}/'"${AWS_BACKUP_ACCESS_KEY_ID}"'/' -i config/gitlab.yml
     sudo -u git -H sed 's,{{AWS_BACKUP_SECRET_ACCESS_KEY}},'"${AWS_BACKUP_SECRET_ACCESS_KEY}"',' -i config/gitlab.yml

--- a/assets/init
+++ b/assets/init
@@ -45,6 +45,12 @@ GITLAB_BACKUPS=${GITLAB_BACKUPS:-disable}
 GITLAB_BACKUP_TIME=${GITLAB_BACKUP_TIME:-04:00}
 GITLAB_BACKUP_EXPIRY=${GITLAB_BACKUP_EXPIRY:-}
 
+AWS_BACKUPS=${AWS_BACKUPS:-false}
+AWS_BACKUP_REGION=${AWS_BACKUP_REGION}
+AWS_BACKUP_ACCESS_KEY_ID=${AWS_BACKUP_ACCESS_KEY_ID}
+AWS_BACKUP_SECRET_ACCESS_KEY=${AWS_BACKUP_SECRET_ACCESS_KEY}
+AWS_BACKUP_BUCKET=${AWS_BACKUP_BUCKET}
+
 NGINX_WORKERS=${NGINX_WORKERS:-1}
 NGINX_ACCEL_BUFFERING=${NGINX_ACCEL_BUFFERING:-no}
 NGINX_PROXY_BUFFERING=${NGINX_PROXY_BUFFERING:-off}
@@ -507,6 +513,20 @@ sudo -u git -H sed 's/{{LDAP_ALLOW_USERNAME_OR_EMAIL_LOGIN}}/'"${LDAP_ALLOW_USER
 sudo -u git -H sed 's/{{LDAP_BLOCK_AUTO_CREATED_USERS}}/'"${LDAP_BLOCK_AUTO_CREATED_USERS}"'/' -i config/gitlab.yml
 sudo -u git -H sed 's/{{LDAP_BASE}}/'"${LDAP_BASE}"'/' -i config/gitlab.yml
 sudo -u git -H sed 's/{{LDAP_USER_FILTER}}/'"${LDAP_USER_FILTER}"'/' -i config/gitlab.yml
+
+# apply aws s3 backup configuration
+case "${AWS_BACKUPS}" in
+  true)
+    sudo -u git -H sed 's/{{AWS_BACKUP_REGION}}/'"${AWS_BACKUP_REGION}"'/' -i config/gitlab.yml
+    sudo -u git -H sed 's/{{AWS_BACKUP_ACCESS_KEY_ID}}/'"${AWS_BACKUP_ACCESS_KEY_ID}"'/' -i config/gitlab.yml
+    sudo -u git -H sed 's,{{AWS_BACKUP_SECRET_ACCESS_KEY}},'"${AWS_BACKUP_SECRET_ACCESS_KEY}"',' -i config/gitlab.yml
+    sudo -u git -H sed 's/{{AWS_BACKUP_BUCKET}}/'"${AWS_BACKUP_BUCKET}"'/' -i config/gitlab.yml
+    ;;
+  *)
+    # remove backup configuration lines
+    sudo -u git -H sed /upload:/,/remote_directory:/d -i config/gitlab.yml
+    ;;
+esac
 
 # apply gravatar configuration
 sudo -u git -H sed 's/{{GITLAB_GRAVATAR_ENABLED}}/'"${GITLAB_GRAVATAR_ENABLED}"'/' -i config/gitlab.yml


### PR DESCRIPTION
Enables use of GitLab integration with Fog to automatically push backups to an S3 bucket.

I noticed there is another [open pull request](https://github.com/sameersbn/docker-gitlab/pull/268) doing this same feature, this setup is much simpler.

I just realized now that Fog supports multiple providers, but I'm not sure how to support complete configuration through environment variables without writing a lot more code.

I've tested this on a production git server and it works with both `app:rake` backups as well as automatic backups. It also disables this behavior when `AWS_BACKUPS=false`