### PR TITLE
Fix support for linked official postgres image

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -159,7 +159,7 @@ elif [ -n "${POSTGRESQL_PORT_5432_TCP_ADDR}" ]; then
 
   # support for linked official postgres image
   DB_USER=${DB_USER:-${POSTGRESQL_ENV_POSTGRES_USER}}
-  DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_POSTGRES_PASS}}
+  DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_POSTGRES_PASSWORD}}
   DB_NAME=${DB_NAME:-${DB_USER}}
 
   # support for linked sameersbn/postgresql image


### PR DESCRIPTION
The init script would look for `POSTGRES_PASS`, but the official docker image only uses `POSTGRES_PASSWORD `