### PR TITLE
OAuth : Fix config build error

### DIFF
--- a/assets/config/gitlabhq/gitlab.yml
+++ b/assets/config/gitlabhq/gitlab.yml
@@ -218,7 +218,7 @@ production: &base
           args: { scope: '{{OAUTH_GITHUB_SCOPE}}' } }
       - { name: 'gitlab', app_id: '{{OAUTH_GITLAB_API_KEY}}',
           app_secret: '{{OAUTH_GITLAB_APP_SECRET}}',
-          args: { scope: '{{OAUTH_GITLAB_SCOPE}}' } },
+          args: { scope: '{{OAUTH_GITLAB_SCOPE}}' } }
       - { name: 'bitbucket', app_id: '{{OAUTH_BITBUCKET_API_KEY}}',
           app_secret: '{{OAUTH_BITBUCKET_APP_SECRET}}'}
       # - { name: 'saml',


### PR DESCRIPTION
Remove the comma to prevent a nasty "Psych::SyntaxError: (<unknown>): did not find expected '-' indicator while parsing a block collection" when using OAuth Gitlab API environment variables.