### PR TITLE
Added `SMTP_CA_ENABLED`, `SMTP_CA_PATH` and `SMTP_CA_FILE` configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,9 @@ Below is the complete list of available options that can be used to customize yo
 - **SMTP_TLS**: Enable SSL/TLS. Defaults to `false`.
 - **SMTP_OPENSSL_VERIFY_MODE**: SMTP openssl verification mode. Accepted values are `none`, `peer`, `client_once` and `fail_if_no_peer_cert`. Defaults to `none`.
 - **SMTP_AUTHENTICATION**: Specify the SMTP authentication method. Defaults to `login` if `SMTP_USER` is set.
+- **SMTP_CA_ENABLED**: Enable custom CA certificates for SMTP email configuration. Defaults to `false`.
+- **SMTP_CA_PATH**: Specify the `ca_path` parameter for SMTP email configuration. Defaults to `/home/git/data/certs`.
+- **SMTP_CA_FILE**: Specify the `ca_file` parameter for SMTP email configuration. Defaults to `/home/git/data/certs/ca.crt`.
 - **LDAP_ENABLED**: Enable LDAP. Defaults to `false`
 - **LDAP_LABEL**: Label to show on login tab for LDAP server. Defaults to 'LDAP'
 - **LDAP_HOST**: LDAP Host

--- a/assets/config/gitlabhq/smtp_settings.rb
+++ b/assets/config/gitlabhq/smtp_settings.rb
@@ -15,6 +15,8 @@ if Rails.env.production?
     authentication: "{{SMTP_AUTHENTICATION}}",
     openssl_verify_mode: "{{SMTP_OPENSSL_VERIFY_MODE}}",
     enable_starttls_auto: {{SMTP_STARTTLS}},
+    ca_path: "{{SMTP_CA_PATH}}",
+    ca_file: "{{SMTP_CA_FILE}}",
     tls: {{SMTP_TLS}}
   }
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,9 @@ SMTP_PASS=${SMTP_PASS:-}
 SMTP_OPENSSL_VERIFY_MODE=${SMTP_OPENSSL_VERIFY_MODE:-none}
 SMTP_STARTTLS=${SMTP_STARTTLS:-true}
 SMTP_TLS=${SMTP_TLS:-false}
+SMTP_CA_ENABLED=${SMTP_CA_ENABLED:-false}
+SMTP_CA_PATH=${SMTP_CA_PATH:-$GITLAB_DATA_DIR/certs}
+SMTP_CA_FILE=${SMTP_CA_FILE:-$GITLAB_DATA_DIR/certs/ca.crt}
 if [[ -n ${SMTP_USER} ]]; then
   SMTP_ENABLED=${SMTP_ENABLED:-true}
   SMTP_AUTHENTICATION=${SMTP_AUTHENTICATION:-login}
@@ -486,6 +489,19 @@ if [[ ${SMTP_ENABLED} == true ]]; then
     "") sudo -HEu ${GITLAB_USER} sed '/{{SMTP_AUTHENTICATION}}/d' -i config/initializers/smtp_settings.rb ;;
     *) sudo -HEu ${GITLAB_USER} sed 's/{{SMTP_AUTHENTICATION}}/'"${SMTP_AUTHENTICATION}"'/' -i config/initializers/smtp_settings.rb ;;
   esac
+
+  if [[ ${SMTP_CA_ENABLED} == true ]]; then
+    if [[ -d ${SMTP_CA_PATH} ]]; then
+      sudo -HEu ${GITLAB_USER} sed 's,{{SMTP_CA_PATH}},'"${SMTP_CA_PATH}"',' -i config/initializers/smtp_settings.rb
+    fi
+
+    if [[ -f ${SMTP_CA_FILE} ]]; then
+      sudo -HEu ${GITLAB_USER} sed 's,{{SMTP_CA_FILE}},'"${SMTP_CA_FILE}"',' -i config/initializers/smtp_settings.rb
+    fi
+  else
+    sudo -HEu ${GITLAB_USER} sed '/{{SMTP_CA_PATH}}/d' -i config/initializers/smtp_settings.rb
+    sudo -HEu ${GITLAB_USER} sed '/{{SMTP_CA_FILE}}/d' -i config/initializers/smtp_settings.rb
+  fi
 fi
 
 # apply LDAP configuration


### PR DESCRIPTION
Without ca_path or ca_file, custom CA certs are not taken into account during the
SMTP SSL/TLS handshake. Since the SMTP email configuration allows the use of CApath
and CAfile for OpenSSL, it should be allowed to set these parameters.

See also:
https://gitlab.com/gitlab-org/omnibus-gitlab/commit/fa9c1464bc1eb173660edfded1a2f7add7ac24b3

Signed-off-by: Scott Fan <fancp2007@gmail.com>