### PR TITLE
Take from resolv.conf rows beginning with 'nameserver'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -759,7 +759,7 @@ if [[ -f /etc/nginx/sites-enabled/gitlab_ci ]]; then
   sed 's/{{GITLAB_HOST}}/'"${GITLAB_HOST}"'/g' -i /etc/nginx/sites-enabled/gitlab_ci
   sed 's/{{GITLAB_CI_HOST}}/'"${GITLAB_CI_HOST}"'/' -i /etc/nginx/sites-enabled/gitlab_ci
 
-  DNS_RESOLVERS=$(cat /etc/resolv.conf  | grep nameserver | awk '{print $2}' ORS=' ')
+  DNS_RESOLVERS=$(cat /etc/resolv.conf  | grep '^\s*nameserver' | awk '{print $2}' ORS=' ')
   sed 's/{{DNS_RESOLVERS}}/'"${DNS_RESOLVERS}"'/' -i /etc/nginx/sites-enabled/gitlab_ci
 fi
 


### PR DESCRIPTION
Our system provider default resolv.conf includes row 
`# nameserver config`

Because of this `DNS_RESOLVERS` included entry `nameserver` and nginx failed to start.

`2015/09/24 19:01:59 [emerg] 382#0: host not found in resolver "nameserver" in /etc/nginx/sites-enabled/gitlab_ci:16`
