### PR TITLE
Add `GITLAB_GIT_HTTP_SERVER_VERSION` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER sameer@damagehead.com
 
 ENV GITLAB_VERSION=8.0.5 \
     GITLAB_SHELL_VERSION=2.6.5 \
+    GITLAB_GIT_HTTP_SERVER_VERSION=0.2.14 \
     GITLAB_USER="git" \
     GITLAB_HOME="/home/git" \
     GITLAB_LOG_DIR="/var/log/gitlab" \

--- a/assets/setup/install.sh
+++ b/assets/setup/install.sh
@@ -51,8 +51,9 @@ cd ${GITLAB_SHELL_INSTALL_DIR}
 sudo -u git -H cp -a config.yml.example config.yml
 sudo -u git -H ./bin/install
 
-echo "Cloning gitlab-git-http-server..."
-sudo -u git -H git clone -q https://gitlab.com/gitlab-org/gitlab-git-http-server.git --depth 1 ${GITLAB_GIT_HTTP_SERVER_INSTALL_DIR}
+echo "Cloning gitlab-git-http-server v.${GITLAB_GIT_HTTP_SERVER_VERSION}..."
+sudo -u git -H git clone -q -b ${GITLAB_GIT_HTTP_SERVER_VERSION} --depth 1 \
+  https://gitlab.com/gitlab-org/gitlab-git-http-server.git ${GITLAB_GIT_HTTP_SERVER_INSTALL_DIR}
 cd ${GITLAB_GIT_HTTP_SERVER_INSTALL_DIR}
 sudo -u git -H make
 


### PR DESCRIPTION
It needs to set gitlab-git-http-server version for compatibility with gitlab 8.0.x.

refs:
https://gitlab.com/gitlab-org/gitlab-git-http-server/issues/12
https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/1603