### PR TITLE
reconfigure openssh server in noninteractive mode

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -320,7 +320,7 @@ fi
 
 if [[ ! -e ${GITLAB_DATA_DIR}/ssh/ssh_host_rsa_key ]]; then
   # create ssh host keys and move them to the data store.
-  dpkg-reconfigure openssh-server
+  dpkg-reconfigure -f noninteractive openssh-server
   mkdir -p ${GITLAB_DATA_DIR}/ssh/
   mv /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub ${GITLAB_DATA_DIR}/ssh/
 fi


### PR DESCRIPTION
dpkg-reconfigure fails to run without a tty, pty, or some such, so tell it to just run.

On first run of the container when ssh keys are generated, `dpkg-configure` fails to create the ssh keys, and the `entrypoint.sh` script fatally errors when it goes to relocate the keys.  Forcing noninteractive mode ensures the ssh keys are created when running `docker-compose up -d` in detached mode.

Fixes #495