### PR TITLE
add: script: add signal handler function when use "docker stop" command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
+RUN rm /usr/bin/supervisord
+COPY supervisord /usr/bin/supervisord
+RUN chmod 755 /usr/bin/supervisord
+
 EXPOSE 22/tcp 80/tcp 443/tcp
 
 VOLUME ["${GITLAB_DATA_DIR}", "${GITLAB_LOG_DIR}"]

--- a/supervisord
+++ b/supervisord
@@ -1,0 +1,16 @@
+#! /usr/bin/python
+# EASY-INSTALL-ENTRY-SCRIPT: 'supervisor==3.0b2','console_scripts','supervisord'
+__requires__ = 'supervisor==3.0b2'
+import sys,os,signal
+from pkg_resources import load_entry_point
+
+def handle_term(a,b):
+    os.system("/etc/init.d/nginx stop");
+    os.system("/etc/init.d/gitlab stop");
+
+signal.signal(signal.SIGTERM.handle_term);
+
+if __name__ == '__main__':
+    sys.exit(
+        load_entry_point('supervisor==3.0b2', 'console_scripts', 'supervisord')()
+    )


### PR DESCRIPTION
When use "docker stop" command to stop container,docker will send SIGTERM to container.And the in this container,the     process whose num is 1 will receive this signal.But if this process didn't do something, docker will kill this container rude. So I add this signal handle function make sure container stop gracefully.