### PR TITLE
Implement unix socket connection to redis

### DIFF
--- a/assets/runtime/config/gitlabhq/resque.yml
+++ b/assets/runtime/config/gitlabhq/resque.yml
@@ -1,4 +1,4 @@
 # If you change this file in a Merge Request, please also create
 # a Merge Request on https://gitlab.com/gitlab-org/omnibus-gitlab/merge_requests
 #
-production: redis://{{REDIS_HOST}}:{{REDIS_PORT}}
+production: {{REDIS_URL}}

--- a/assets/runtime/env-defaults
+++ b/assets/runtime/env-defaults
@@ -47,6 +47,7 @@ case ${DB_TYPE} in
 esac
 
 ## REDIS
+REDIS_SOCKET=${REDIS_SOCKET:-/var/run/redis/redis.sock}
 REDIS_HOST=${REDIS_HOST:-}
 REDIS_PORT=${REDIS_PORT:-}
 

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -202,14 +202,27 @@ gitlab_configure_database() {
 gitlab_finalize_redis_parameters() {
   # is a redis container linked?
   if [[ -n ${REDISIO_PORT_6379_TCP_ADDR} ]]; then
-    REDIS_HOST=${REDIS_HOST:-${REDISIO_PORT_6379_TCP_ADDR}}
-    REDIS_PORT=${REDIS_PORT:-${REDISIO_PORT_6379_TCP_PORT}}
+    if [[ -S ${REDIS_SOCKET} ]]; then
+      REDIS_CONNECTION="unix"
+    else
+      REDIS_HOST=${REDIS_HOST:-${REDISIO_PORT_6379_TCP_ADDR}}
+      REDIS_PORT=${REDIS_PORT:-${REDISIO_PORT_6379_TCP_PORT}}
+      REDIS_CONNECTION="redis"
+    fi
+  else
+      REDIS_CONNECTION="redis"
+      # set default redis port if not specified
+      REDIS_PORT=${REDIS_PORT:-6379}
   fi
 
-  # set default redis port if not specified
-  REDIS_PORT=${REDIS_PORT:-6379}
 
-  if [[ -z ${REDIS_HOST} ]]; then
+  if [[ ${REDIS_CONNECTION} == redis ]]; then
+    REDIS_URL="redis://${REDIS_HOST}:${REDIS_PORT}"
+  else
+    REDIS_URL="unix://${REDIS_SOCKET}"
+  fi
+
+  if [[ -z ${REDIS_URL} ]]; then
     echo
     echo "ERROR: "
     echo "  Please configure the redis connection."
@@ -221,8 +234,16 @@ gitlab_finalize_redis_parameters() {
 }
 
 gitlab_check_redis_connection() {
+  case ${REDIS_CONNECTION} in
+    unix)
+      prog="redis-cli -s ${REDIS_SOCKET} ping"
+      ;;
+    redis)
+      prog="redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} ping"
+      ;;
+  esac
   timeout=60
-  while ! redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} ping >/dev/null 2>&1
+  while ! ${prog} >/dev/null 2>&1
   do
     timeout=$(expr $timeout - 1)
     if [[ $timeout -eq 0 ]]; then
@@ -238,13 +259,10 @@ gitlab_check_redis_connection() {
 
 gitlab_configure_redis() {
   echo -n "Configuring gitlab::redis"
-
   gitlab_finalize_redis_parameters
   gitlab_check_redis_connection
-
   update_template ${GITLAB_RESQUE_CONFIG} \
-    REDIS_HOST \
-    REDIS_PORT
+    REDIS_URL
 }
 
 gitlab_configure_gitlab_workhorse() {

--- a/docker-compose.sockets.yml
+++ b/docker-compose.sockets.yml
@@ -1,0 +1,72 @@
+postgresql:
+  restart: always
+  image: sameersbn/postgresql:9.4-11
+  environment:
+    - DB_USER=gitlab
+    - DB_PASS=password
+    - DB_NAME=gitlabhq_production
+  volumes:
+    - /srv/docker/gitlab/postgresql:/var/lib/postgresql
+
+sockets:
+  build: sockets-dvc
+
+gitlab:
+  restart: always
+  image: sameersbn/gitlab
+  links:
+    - redis:redisio
+    - postgresql:postgresql
+  ports:
+    - "10080:80"
+    - "10022:22"
+  environment:
+    - DEBUG=false
+    - TZ=Asia/Kolkata
+    - GITLAB_TIMEZONE=Kolkata
+
+    - GITLAB_SECRETS_DB_KEY_BASE=long-and-random-alphanumeric-string
+
+    - GITLAB_HOST=localhost
+    - GITLAB_PORT=10080
+    - GITLAB_SSH_PORT=10022
+    - GITLAB_RELATIVE_URL_ROOT=
+
+    - GITLAB_NOTIFY_ON_BROKEN_BUILDS=true
+    - GITLAB_NOTIFY_PUSHER=false
+
+    - GITLAB_EMAIL=notifications@example.com
+    - GITLAB_EMAIL_REPLY_TO=noreply@example.com
+    - GITLAB_INCOMING_EMAIL_ADDRESS=reply@example.com
+
+    - GITLAB_BACKUP_SCHEDULE=daily
+    - GITLAB_BACKUP_TIME=01:00
+
+    - SMTP_ENABLED=false
+    - SMTP_DOMAIN=www.example.com
+    - SMTP_HOST=smtp.gmail.com
+    - SMTP_PORT=587
+    - SMTP_USER=mailer@example.com
+    - SMTP_PASS=password
+    - SMTP_STARTTLS=true
+    - SMTP_AUTHENTICATION=login
+
+    - IMAP_ENABLED=false
+    - IMAP_HOST=imap.gmail.com
+    - IMAP_PORT=993
+    - IMAP_USER=mailer@example.com
+    - IMAP_PASS=password
+    - IMAP_SSL=true
+    - IMAP_STARTTLS=false
+  volumes:
+    - /srv/docker/gitlab/gitlab:/home/git/data
+  volumes_from:
+    - sockets
+
+redis:
+  restart: always
+  image: sameersbn/redis:latest
+  volumes:
+    - /srv/docker/gitlab/redis:/var/lib/redis
+  volumes_from:
+    - sockets

--- a/sockets-dvc/Dockerfile
+++ b/sockets-dvc/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox
+
+MAINTAINER ivlis
+
+RUN mkdir -p /var/run/redis/
+
+VOLUME /var/run/redis/
+
+CMD /bin/true


### PR DESCRIPTION
This is the first step to create a full unix socket based scheme of
communications between the related containers.

Sockets-dvc is a new DVC that will contain all sockets.

The socket connection is used if the linked redis container is used and
a socket is available inside the docker container. Otherwise, we fall
back to a tcp connection.

Fixes #548 
