### PR TITLE
Use official docker in docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: gitlab/dind
+image: docker:dind
 
 deploy:
   script:


### PR DESCRIPTION
Since 1.10 CI runner does not require dind to have a bash installed anymore.

From now on, we can use the official dind image.