### PR TITLE
GITLAB_REGISTRY_PATH is really GITLAB_REGISTRY_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_REGISTRY_PORT**: Sets the GitLab Registry Port. Defaults to `5000`.
 - **GITLAB_REGISTRY_API_URL**: Sets the Gitlab Registry API URL. Defaults to `http://localhost:5000`
 - **GITLAB_REGISTRY_KEY_PATH**: Sets the GitLab Registry Key Path. Defaults to `config/registry.key`
-- **GITLAB_REGISTRY_PATH**: Sets the GitLab Registry PATH. Defaults to `shared/registry`.
+- **GITLAB_REGISTRY_DIR**: Sets the GitLab Registry PATH. Defaults to `shared/registry`.
 - **GITLAB_REGISTRY_ISSUER**: Sets the Gitlab Registry Issuer. Defaults to `gitlab-issuer`.
 - **GITLAB_HTTPS**: Set to `true` to enable https support, disabled by default.
 - **SSL_SELF_SIGNED**: Set to `true` when using self signed ssl certificates. `false` by default.


### PR DESCRIPTION
The README says `GITLAB_REGISTRY_PATH`, but in all scripts `GITLAB_REGISTRY_DIR` is used.