### PR TITLE
Guide on reusing docker host SSH server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
         - [Microsoft Azure](#microsoft-azure)
     - [External Issue Trackers](#external-issue-trackers)
     - [Host UID / GID Mapping](#host-uid--gid-mapping)
+    - [Reuse docker host SSH daemon](docs/docker_host_ssh.md)
     - [Piwik](#piwik)
     - [Available Configuration Parameters](#available-configuration-parameters)
 - [Maintenance](#maintenance)

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -1,7 +1,7 @@
 Reuse docker host SSH daemon
 ============================
 
-It is possible to use the SSH daemon that runs on the docker host instead of using a separate SSH port for Gitlab.
+It is possible to use the SSH daemon that runs on the docker host instead of using a separate SSH port for GitLab.
 
 ## Setup
 

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -59,7 +59,7 @@ git clone git@docker.host:group/project.git
 
 ## Advanced: Use default UID/GID in the container
 
-if you rely on the default `uid` and `git`, for example if you link GitLab to [sameersbn/redmine](https://github.com/sameersbn/docker-redmine) container, you can run the container without UID/GID mapping and use [incron](http://inotify.aiken.cz/?section=incron&page=about&lang=en) to keep `.ssh/authorized_keys` accessible by host `git` user:
+If you rely on the default `uid` and `gid`, for example if you link GitLab to [sameersbn/redmine](https://github.com/sameersbn/docker-redmine) container, you can run the container without UID/GID mapping and use [incron](http://inotify.aiken.cz/?section=incron&page=about&lang=en) to keep `.ssh/authorized_keys` accessible by host `git` user:
 
 ```bash
 docker run --name gitlab -it --rm [options] \

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -52,6 +52,19 @@ docker run --name gitlab -it --rm [options] \
     sameersbn/gitlab:8.11.3
 ```
 
+Create the script at `/srv/gitlab/data/fix_ssh_permissions.incron.sh`:
+
+```bash
+#!/bin/bash
+[ -e "$1" ] && chgrp git "$1" && chmod g+r$([ -d "$1" ] && echo x) "$1"
+```
+
+Make it executable:
+
+```bash
+chmod +x /srv/gitlab/data/fix_ssh_permissions.incron.sh
+```
+
 Install incron:
 
 ```bash
@@ -68,11 +81,8 @@ incrontab -e
 and paste this:
 
 ```
-/srv/gitlab/data/.ssh IN_ATTRIB,IN_ONLYDIR chmod 755 $@
-/srv/gitlab/data/.ssh/authorized_keys IN_ATTRIB chmod 644 $@
+/srv/gitlab/data/.ssh IN_ATTRIB /srv/gitlab/data/fix_ssh_permissions.incron.sh $@/$#
 ```
-
-**PLEASE NOTE: keeping `.authorized_keys` world-readable brings a security risk. Use this method with discretion.**
 
 ## Access GitLab
 

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -1,0 +1,83 @@
+Reuse docker host SSH daemon
+============================
+
+It is possible to use the SSH daemon that runs on the docker host instead of using a separate SSH port for Gitlab.
+
+## Setup
+
+Create the system `git` user if necessary (make sure it is added to `docker` group and has a working shell):
+
+```bash
+useradd --system git --home-dir /srv/docker/gitlab/data --groups docker
+```
+
+Note that the home directory must point to GitLab data directory, as it takes `.ssh/authorized_keys` from there.
+
+Now create `gitlab-shell` home directory at the same location as in the container:
+
+```bash
+mkdir -p /home/git/gitlab-shell/bin
+```
+
+Create the shell proxy script at `/home/git/gitlab-shell/bin/gitlab-shell`:
+
+```bash
+#!/bin/bash
+# Proxy SSH requests to docker container
+docker exec -i -u git gitlab sh -c "SSH_CONNECTION='$SSH_CONNECTION' SSH_ORIGINAL_COMMAND='$SSH_ORIGINAL_COMMAND' $0 $1"
+```
+
+Make it executable:
+
+```bash
+chmod +x /home/git/gitlab-shell/bin/gitlab-shell
+```
+
+## Run GitLab
+
+Start the container, mapping the `uid` and `gid` of host `git` user:
+
+```bash
+docker run --name gitlab -it --rm [options] \
+    --env "USERMAP_UID=$(id -u git)" --env "USERMAP_GID=$(id -g git)" \
+    sameersbn/gitlab:8.11.3
+```
+
+### (Optional) Use default UID/GID in the container
+
+if you rely on the default `uid` and `git`, for example if you link GitLab to [sameersbn/redmine](https://github.com/sameersbn/docker-redmine) container, you can run the container without UID/GID mapping and use [incron](http://inotify.aiken.cz/?section=incron&page=about&lang=en) to keep `.ssh/authorized_keys` accessible by host `git` user:
+
+```bash
+docker run --name gitlab -it --rm [options] \
+    sameersbn/gitlab:8.11.3
+```
+
+Install incron:
+
+```bash
+apt-get install -y incron
+echo root >> /etc/incron.allow
+```
+
+Open incrontab editor:
+
+```bash
+incrontab -e
+```
+
+and paste this:
+
+```
+/srv/gitlab/data/.ssh IN_ATTRIB,IN_ONLYDIR chmod 755 $@
+/srv/gitlab/data/.ssh/authorized_keys IN_ATTRIB chmod 644 $@
+```
+
+**PLEASE NOTE: keeping `.authorized_keys` world-readable brings a security risk. Use this method with discretion.**
+
+## Access GitLab
+
+Use Docker host to access repositories:
+
+```bash
+git clone git@docker.host:group/project.git
+```

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -56,7 +56,9 @@ Create the script at `/srv/gitlab/data/fix_ssh_permissions.incron.sh`:
 
 ```bash
 #!/bin/bash
-[ -e "$1" ] && chgrp git "$1" && chmod g+r$([ -d "$1" ] && echo x) "$1"
+[ $(stat -c %G "$1") != "git" ] && chgrp git "$1"
+[ -f "$1" -a $(stat -c %a "$1") != 640 ] && chmod 640 "$1"
+[ -d "$1" -a $(stat -c %a "$1") != 710 ] && chmod 710 "$1"
 ```
 
 Make it executable:

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -94,6 +94,13 @@ touch /srv/docker/gitlab/data/.ssh
 touch /srv/docker/gitlab/data/.ssh/authorized_keys
 ```
 
+Ensure that OpenSSH is running without `StrictModes`:
+
+```
+sed -i 's/StrictModes yes/StrictModes no/' /etc/ssh/sshd_config
+/etc/init.d/ssh reload
+```
+
 ## Access GitLab
 
 Use Docker host to access repositories:

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -49,7 +49,15 @@ docker run --name gitlab -it --rm [options] \
     sameersbn/gitlab:8.11.3
 ```
 
-### (Optional) Use default UID/GID in the container
+## Access GitLab
+
+Use Docker host SSH server to access repositories:
+
+```bash
+git clone git@docker.host:group/project.git
+```
+
+## Advanced: Use default UID/GID in the container
 
 if you rely on the default `uid` and `git`, for example if you link GitLab to [sameersbn/redmine](https://github.com/sameersbn/docker-redmine) container, you can run the container without UID/GID mapping and use [incron](http://inotify.aiken.cz/?section=incron&page=about&lang=en) to keep `.ssh/authorized_keys` accessible by host `git` user:
 
@@ -58,7 +66,7 @@ docker run --name gitlab -it --rm [options] \
     sameersbn/gitlab:8.11.3
 ```
 
-Create the script at `/srv/docker/gitlab/data/fix_ssh_permissions.incron.sh`:
+Create the script at `/srv/docker/gitlab/fix_ssh_permissions.incron.sh`:
 
 ```bash
 #!/bin/bash
@@ -70,7 +78,7 @@ Create the script at `/srv/docker/gitlab/data/fix_ssh_permissions.incron.sh`:
 Make it executable:
 
 ```bash
-chmod +x /srv/docker/gitlab/data/fix_ssh_permissions.incron.sh
+chmod +x /srv/docker/gitlab/fix_ssh_permissions.incron.sh
 ```
 
 Install incron:
@@ -89,7 +97,7 @@ incrontab -e
 and paste this:
 
 ```
-/srv/docker/gitlab/data/.ssh IN_ATTRIB /srv/docker/gitlab/data/fix_ssh_permissions.incron.sh $@/$#
+/srv/docker/gitlab/data/.ssh IN_ATTRIB /srv/docker/gitlab/fix_ssh_permissions.incron.sh $@/$#
 ```
 
 Start incrond and touch `authorized_keys` to have the permissions fixed:
@@ -105,12 +113,4 @@ Ensure that OpenSSH is running without `StrictModes`:
 ```
 sed -i 's/StrictModes yes/StrictModes no/' /etc/ssh/sshd_config
 /etc/init.d/ssh reload
-```
-
-## Access GitLab
-
-Use Docker host to access repositories:
-
-```bash
-git clone git@docker.host:group/project.git
 ```

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -5,13 +5,13 @@ It is possible to use the SSH daemon that runs on the docker host instead of usi
 
 ## Setup
 
-Create the system `git` user if necessary (make sure it is added to `docker` group and has a working shell):
+Create the system `git` user if necessary (make sure it has a working shell):
 
 ```bash
-useradd --system git --home-dir /srv/docker/gitlab/data --groups docker
+useradd --system git --home-dir /srv/docker/gitlab/data
 ```
 
-Note that the home directory must point to GitLab data directory, as it takes `.ssh/authorized_keys` from there.
+The home directory must point to GitLab data directory, as it takes `.ssh/authorized_keys` from there.
 
 Now create `gitlab-shell` home directory at the same location as in the container:
 
@@ -24,13 +24,19 @@ Create the shell proxy script at `/home/git/gitlab-shell/bin/gitlab-shell`:
 ```bash
 #!/bin/bash
 # Proxy SSH requests to docker container
-docker exec -i -u git gitlab sh -c "SSH_CONNECTION='$SSH_CONNECTION' SSH_ORIGINAL_COMMAND='$SSH_ORIGINAL_COMMAND' $0 $1"
+sudo docker exec -i -u git gitlab sh -c "SSH_CONNECTION='$SSH_CONNECTION' SSH_ORIGINAL_COMMAND='$SSH_ORIGINAL_COMMAND' $0 $1"
 ```
 
 Make it executable:
 
 ```bash
 chmod +x /home/git/gitlab-shell/bin/gitlab-shell
+```
+
+Allow `git` user limited sudo access to execute a command inside GitLab docker container:
+
+```bash
+echo "git ALL=NOPASSWD: /usr/bin/docker exec -i -u git gitlab *" > /etc/sudoers.d/docker-gitlab
 ```
 
 ## Run GitLab

--- a/docs/docker_host_ssh.md
+++ b/docs/docker_host_ssh.md
@@ -52,7 +52,7 @@ docker run --name gitlab -it --rm [options] \
     sameersbn/gitlab:8.11.3
 ```
 
-Create the script at `/srv/gitlab/data/fix_ssh_permissions.incron.sh`:
+Create the script at `/srv/docker/gitlab/data/fix_ssh_permissions.incron.sh`:
 
 ```bash
 #!/bin/bash
@@ -64,7 +64,7 @@ Create the script at `/srv/gitlab/data/fix_ssh_permissions.incron.sh`:
 Make it executable:
 
 ```bash
-chmod +x /srv/gitlab/data/fix_ssh_permissions.incron.sh
+chmod +x /srv/docker/gitlab/data/fix_ssh_permissions.incron.sh
 ```
 
 Install incron:
@@ -83,7 +83,15 @@ incrontab -e
 and paste this:
 
 ```
-/srv/gitlab/data/.ssh IN_ATTRIB /srv/gitlab/data/fix_ssh_permissions.incron.sh $@/$#
+/srv/docker/gitlab/data/.ssh IN_ATTRIB /srv/docker/gitlab/data/fix_ssh_permissions.incron.sh $@/$#
+```
+
+Start incrond and touch `authorized_keys` to have the permissions fixed:
+
+```
+/etc/init.d/incrond start
+touch /srv/docker/gitlab/data/.ssh
+touch /srv/docker/gitlab/data/.ssh/authorized_keys
 ```
 
 ## Access GitLab


### PR DESCRIPTION
This PR adds explanation on how to use the SSH daemon on the Docker host to connect to Gitlab, and adds the option to set more relaxed permissions if needed (see #725). This needs proofreading at the very least.
