### PR TITLE
Added Docker Labels from label-schema.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,18 @@ ENV GITLAB_INSTALL_DIR="${GITLAB_HOME}/gitlab" \
     GITLAB_BUILD_DIR="${GITLAB_CACHE_DIR}/build" \
     GITLAB_RUNTIME_DIR="${GITLAB_CACHE_DIR}/runtime"
 
+# Basic build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.docker.dockerfile="/Dockerfile" \
+      org.label-schema.license="MIT" \
+      org.label-schema.name="Docker Gitlab" \
+      org.label-schema.url="http://www.damagehead.com/docker-gitlab/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/sameersbn/docker-gitlab.git" \
+      org.label-schema.vcs-type="Git"
+
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E1DD270288B4E6030699E45FA1715D88E1DF1F24 \
  && echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,14 @@ help:
 	@echo "   5. make purge        - stop and remove the container"
 
 build:
-	@docker build --tag=sameersbn/gitlab .
+	@docker build --tag=sameersbn/gitlab \
+								--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+								--build-arg VCS_REF=`git rev-parse --short HEAD` .
 
 release: build
-	@docker build --tag=sameersbn/gitlab:$(shell cat VERSION) .
+	@docker build --tag=sameersbn/gitlab:$(shell cat VERSION) \
+								--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+								--build-arg VCS_REF=`git rev-parse --short HEAD` .
 
 quickstart:
 	@echo "Starting postgresql container..."


### PR DESCRIPTION
Hey Sameer! I'm working with some folks in the container community on a standard label schema. To get momentum we want to encourage as many people as possible to label their public container images.

To make it as easy as possible for you, here's a PR that will label your image automatically as part of your existing build process.

Once the labels are in place you could use MicroBadger (microbadger.com) to create image badges for jumping between your Docker Image and the appropriate commit on Github.

And if you're interested in getting involved with the label standardization, please jump on in at label-schema.org.
