### PR TITLE
Fix smtp_settings to make mail work

### DIFF
--- a/assets/runtime/config/gitlabhq/smtp_settings.rb
+++ b/assets/runtime/config/gitlabhq/smtp_settings.rb
@@ -10,6 +10,7 @@
 if Rails.env.production?
   Rails.application.config.action_mailer.delivery_method = :smtp
 
+  ActionMailer::Base.default_delivery = :smtp
   ActionMailer::Base.smtp_settings = {
     address: "{{SMTP_HOST}}",
     port: {{SMTP_PORT}},


### PR DESCRIPTION
During  RC's of 8.9 some trouble causes mail won't work. This will be patched in `config/initializers/smtp_settings.rb.sample` in the next version (`8.9.1`)  but we could adopt it earlier because we set  our own `smtp_settings.rb` in our configs. 

To get an better understanding of the problem read the issues in the upstream. (https://gitlab.com/gitlab-org/gitlab-ce/issues/19132)

This will fixes the health_check and mails will sent again furthermore it will fix the problem of #757 .

What do you think ? Should we make a new release with `8.9.0-1`.

/cc @sameersbn 