### PR TITLE
Update Information to GITLAB_SECRETS_DB_KEY_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The quickest way to get started is using [docker-compose](https://docs.docker.co
 wget https://raw.githubusercontent.com/sameersbn/docker-gitlab/master/docker-compose.yml
 ```
 
-Generate a random string and assign to `GITLAB_SECRETS_DB_KEY_BASE` environment variable. Once set you should not change this value and ensure you backup this value.
+Generate a random string that is at least `32` characters long and assign to `GITLAB_SECRETS_DB_KEY_BASE` environment variable. Once set you should not change this value and ensure you backup this value.
 
 > **Tip**: You can generate a random string using `pwgen -Bsv1 64` and assign it as the value of `GITLAB_SECRETS_DB_KEY_BASE`.
 
@@ -782,7 +782,7 @@ Below is the complete list of available options that can be used to customize yo
 - **GITLAB_HOST**: The hostname of the GitLab server. Defaults to `localhost`
 - **GITLAB_CI_HOST**: If you are migrating from GitLab CI use this parameter to configure the redirection to the GitLab service so that your existing runners continue to work without any changes. No defaults.
 - **GITLAB_PORT**: The port of the GitLab server. This value indicates the public port on which the GitLab application will be accessible on the network and appropriately configures GitLab to generate the correct urls. It does not affect the port on which the internal nginx server will be listening on. Defaults to `443` if `GITLAB_HTTPS=true`, else defaults to `80`.
-- **GITLAB_SECRETS_DB_KEY_BASE**: Used to encrypt build variables. Ensure that you don't lose it. You can generate one using `pwgen -Bsv1 64`. If you are migrating from GitLab CI, you need to set this value to the value of `GITLAB_CI_SECRETS_DB_KEY_BASE`. No defaults.
+- **GITLAB_SECRETS_DB_KEY_BASE**: Encryption key for special GitLab variables in the database. Ensure that your key is at least 32 characters long and that you don't lose it. You can generate one using `pwgen -Bsv1 64`. If you are migrating from GitLab CI, you need to set this value to the value of `GITLAB_CI_SECRETS_DB_KEY_BASE`. No defaults.
 - **GITLAB_TIMEZONE**: Configure the timezone for the gitlab application. This configuration does not effect cron jobs. Defaults to `UTC`. See the list of [acceptable values](http://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html).
 - **GITLAB_ROOT_PASSWORD**: The password for the root user on firstrun. Defaults to `5iveL!fe`.
 - **GITLAB_ROOT_EMAIL**: The email for the root user on firstrun. Defaults to `admin@example.com`

--- a/assets/runtime/config/gitlabhq/secrets.yml
+++ b/assets/runtime/config/gitlabhq/secrets.yml
@@ -1,7 +1,7 @@
 production:
   # db_key_base is used to encrypt for Variables. Ensure that you don't lose it.
   # If you change or lose this key you will be unable to access variables stored in database.
-  # Make sure the secret is at least 30 characters and all random,
+  # Make sure the secret is at least 32 characters and all random,
   # no regular words or you'll be exposed to dictionary attacks.
   db_key_base: {{GITLAB_SECRETS_DB_KEY_BASE}}
 


### PR DESCRIPTION
This comes through an bug in the upstream a related issue to that was created (https://gitlab.com/gitlab-org/gitlab-ce/issues/19073). We should inform new users that use `8.9.x`. They need at least 32 characters long key for `GITLAB_SECRETS_DB_KEY_BASE` otherwise they will got problems. It will be fixed in the upstream in the next patch hopefully.