### PR TITLE
Use tcp for workhorse communication.

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -260,8 +260,8 @@ directory=${GITLAB_INSTALL_DIR}
 environment=HOME=${GITLAB_HOME}
 command=/usr/local/bin/gitlab-workhorse
   -listenUmask 0
-  -listenNetwork unix
-  -listenAddr ${GITLAB_INSTALL_DIR}/tmp/sockets/gitlab-workhorse.socket
+  -listenNetwork tcp
+  -listenAddr ":8181"
   -authBackend http://127.0.0.1:8080{{GITLAB_RELATIVE_URL_ROOT}}
   -authSocket ${GITLAB_INSTALL_DIR}/tmp/sockets/gitlab.socket
   -documentRoot ${GITLAB_INSTALL_DIR}/public

--- a/assets/runtime/config/nginx/gitlab
+++ b/assets/runtime/config/nginx/gitlab
@@ -17,7 +17,7 @@
 ## See installation.md#using-https for additional HTTPS configuration details.
 
 upstream gitlab-workhorse {
-  server unix:{{GITLAB_INSTALL_DIR}}/tmp/sockets/gitlab-workhorse.socket fail_timeout=0;
+  server localhost:8181 fail_timeout=0;
 }
 
 ## Normal HTTP host

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -21,7 +21,7 @@
 ## See installation.md#using-https for additional HTTPS configuration details.
 
 upstream gitlab-workhorse {
-  server unix:{{GITLAB_INSTALL_DIR}}/tmp/sockets/gitlab-workhorse.socket fail_timeout=0;
+  server localhost:8181 fail_timeout=0;
 }
 
 ## Redirects all HTTP traffic to the HTTPS host


### PR DESCRIPTION
Hey, 
this is one part of #791 migration. I would like to use this to make it simpler to change a load balancer or use no one for GitLab.  We could know adopt a load balancer container in the gitlab network or create a new network with the gitlab container and every other container can communicate with gitlab over `8181`. This doesn't impact the current behaviour it adds only more flexibility. WDYT ? @sameersbn 