### PR TITLE
Improve error when ssl key, ssl certificate or DH param were not found.

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1165,7 +1165,7 @@ install_configuration_templates() {
     if [[ -f ${SSL_CERTIFICATE_PATH} && -f ${SSL_KEY_PATH} && -f ${SSL_DHPARAM_PATH} ]]; then
       install_template root: nginx/gitlab-ssl ${GITLAB_NGINX_CONFIG}
     else
-      echo "SSL keys and certificates were not found."
+      echo "SSL Key, SSL Certificate and DHParam were not found."
       echo "Assuming that the container is running behind a HTTPS enabled load balancer."
       install_template root: nginx/gitlab ${GITLAB_NGINX_CONFIG}
     fi


### PR DESCRIPTION
This is a better error message when the configuration of nginx fails.