### PR TITLE
Remove imagelayers.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Docker Repository on Quay.io](https://quay.io/repository/sameersbn/gitlab/status "Docker Repository on Quay.io")](https://quay.io/repository/sameersbn/gitlab) [![](https://badge.imagelayers.io/sameersbn/gitlab.svg)](https://imagelayers.io/?images=sameersbn/gitlab:latest 'Get your own badge on imagelayers.io')
-
+[![Docker Repository on Quay.io](https://quay.io/repository/sameersbn/gitlab/status "Docker Repository on Quay.io")](https://quay.io/repository/sameersbn/gitlab) 
 # sameersbn/gitlab:8.10.4
 
 - [Introduction](#introduction)


### PR DESCRIPTION
The link isn't working anymore. If you click it will redirect you to imagelayers.io but i can't display our layers.