### PR TITLE
Update docker-compose.yml example

### DIFF
--- a/docs/container_registry.md
+++ b/docs/container_registry.md
@@ -83,6 +83,7 @@ services:
     - --loglevel warning
     volumes:
     - ./redis:/var/lib/redis:Z
+
   postgresql:
     restart: always
     image: sameersbn/postgresql:9.5
@@ -94,14 +95,31 @@ services:
     - DB_NAME=gitlabhq_production
     - DB_EXTENSION=pg_trgm
 
+  registry:
+    restart: always
+    image: registry:2.4.1
+    volumes:
+    - ./gitlab/shared/registry:/registry
+    - ./certs:/certs
+    environment:
+    - REGISTRY_LOG_LEVEL=info
+    - REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/registry
+    - REGISTRY_AUTH_TOKEN_REALM=https://gitlab.example.com:10443/jwt/auth
+    - REGISTRY_AUTH_TOKEN_SERVICE=container_registry
+    - REGISTRY_AUTH_TOKEN_ISSUER=gitlab-issuer
+    - REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/certs/registry-auth.crt
+    - REGISTRY_STORAGE_DELETE_ENABLED=true
+
   gitlab:
     restart: always
     image: sameersbn/gitlab:8.10.5
     depends_on:
     - redis
     - postgresql
+    - registry
     ports:
     - "10080:80"
+    - "100443:443"
     - "5500:5500"
     - "10022:22"
     volumes:
@@ -132,21 +150,10 @@ services:
     - GITLAB_REGISTRY_KEY_PATH=/certs/registry-auth.key
     - SSL_REGISTRY_KEY_PATH=/certs/registry.key
     - SSL_REGISTRY_CERT_PATH=/certs/registry.crt
-
-  registry:
-    restart: always
-    image: registry:2.4.1
-    volumes:
-    - ./gitlab/shared/registry:/registry
-    - ./certs:/certs
-    environment:
-    - REGISTRY_LOG_LEVEL=info
-    - REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/registry
-    - REGISTRY_AUTH_TOKEN_REALM=http://gitlab.example.com:10080/jwt/auth
-    - REGISTRY_AUTH_TOKEN_SERVICE=container_registry
-    - REGISTRY_AUTH_TOKEN_ISSUER=gitlab-issuer
-    - REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/certs/registry-auth.crt
-    - REGISTRY_STORAGE_DELETE_ENABLED=true
+    - GITLAB_HTTPS=true
+    - SSL_CERTIFICATE_PATH=/certs/gitlab.pem
+    - SSL_KEY_PATH=/certs/gitlab.key
+    - SSL_DHPARAM_PATH=/certs/dhparam.pem
 ```
 > **Important Notice**
 >


### PR DESCRIPTION
1. Adds a `registry` dependency to the `gitlab` service

`gitlab` refers to the `registry` service through Docker's internal
network.
1. Specify HTTPS configuration variables

This example shows which parameters are needed to enable HTTPS in
GitLab. Also added a port mapping for HTTPS.
