### PR TITLE
Change `GITLAB_CLONE_URL` from github to gitlab directly

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GITLAB_CLONE_URL=https://github.com/gitlabhq/gitlabhq.git
+GITLAB_CLONE_URL=https://gitlab.com/gitlab-org/gitlab-ce.git
 GITLAB_SHELL_URL=https://gitlab.com/gitlab-org/gitlab-shell/repository/archive.tar.gz
 GITLAB_WORKHORSE_URL=https://gitlab.com/gitlab-org/gitlab-workhorse/repository/archive.tar.gz
 


### PR DESCRIPTION
So I would prefer to use GitLab directly as clone url. I saw the first difference now on GitHub (8.11.0-rc2 isn't released). All other realated components will be fetched from GiLlab. I think it would be more consistent. If you like it feel free to merge it otherwise I would like to know what are you thinking about it.
