### PR TITLE
UID/GID non-unique fix

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -957,7 +957,7 @@ map_uidgid() {
   USERMAP_UID=${USERMAP_UID:-$USERMAP_ORIG_UID}
   if [[ ${USERMAP_UID} != ${USERMAP_ORIG_UID} ]] || [[ ${USERMAP_GID} != ${USERMAP_ORIG_GID} ]]; then
     echo "Mapping UID and GID for ${GITLAB_USER}:${GITLAB_USER} to $USERMAP_UID:$USERMAP_GID"
-    groupmod -g ${USERMAP_GID} ${GITLAB_USER}
+    groupmod -o -g ${USERMAP_GID} ${GITLAB_USER}
     sed -i -e "s|:${USERMAP_ORIG_UID}:${USERMAP_GID}:|:${USERMAP_UID}:${USERMAP_GID}:|" /etc/passwd
     find ${GITLAB_HOME} -path ${GITLAB_DATA_DIR}/\* -prune -o -print0 | xargs -0 chown -h ${GITLAB_USER}:
   fi


### PR DESCRIPTION
Complete details for PR: https://github.com/sameersbn/docker-postgresql/pull/78

allow non-unique id's, because the gid selected by the user may already be in use within the container. This fix solves that issue.

Docker error log:
```
Adapting uid and gid for postgres:postgres to 1024:101
groupmod: GID '101' already exists
```

Error within log means that GID: 101 is already in use within the container.
By using groupmod with option ```-o``` it will be allowed.