### PR TITLE
Add missing SMTP_SSL to smtp_settings.rb

### DIFF
--- a/assets/runtime/config/gitlabhq/smtp_settings.rb
+++ b/assets/runtime/config/gitlabhq/smtp_settings.rb
@@ -23,6 +23,6 @@ if Rails.env.production?
     ca_path: "{{SMTP_CA_PATH}}",
     ca_file: "{{SMTP_CA_FILE}}",
     tls: {{SMTP_TLS}},
-	ssl: {{SMTP_SSL}}
+    ssl: {{SMTP_SSL}}
   }
 end

--- a/assets/runtime/config/gitlabhq/smtp_settings.rb
+++ b/assets/runtime/config/gitlabhq/smtp_settings.rb
@@ -22,6 +22,7 @@ if Rails.env.production?
     openssl_verify_mode: "{{SMTP_OPENSSL_VERIFY_MODE}}",
     ca_path: "{{SMTP_CA_PATH}}",
     ca_file: "{{SMTP_CA_FILE}}",
-    tls: {{SMTP_TLS}}
+    tls: {{SMTP_TLS}},
+	ssl: {{SMTP_SSL}}
   }
 end


### PR DESCRIPTION
`SMTP_SSL` was missing from smtp_settings.rb, making it impossible to keep an SSL configuration (one had to manually edit the file every time the container started up). This should solve the problem.