### PR TITLE
Switching from ReplicationController to Deployment.

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -12,11 +12,11 @@ do
   kubectl -f $svc create
 done
 
-# create the replication controllers
-for rc in *-rc.yml
+# create the deployments
+for deploy in *-deploy.yml
 do
-  echo -n "Creating $rc... "
-  kubectl -f $rc create
+  echo -n "Applying $deploy... "
+  kubectl create -f $deploy --record
 done
 
 # list pod,rc,svc

--- a/kubernetes/gitlab-deploy.yml
+++ b/kubernetes/gitlab-deploy.yml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: gitlab
 spec:
   replicas: 1
   selector:
-    name: gitlab
+    matchLabels:
+      name: gitlab
   template:
     metadata:
       name: gitlab

--- a/kubernetes/postgresql-deploy.yml
+++ b/kubernetes/postgresql-deploy.yml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: postgresql
 spec:
   replicas: 1
   selector:
-    name: postgresql
+    matchLabels:
+      name: postgresql
   template:
     metadata:
       name: postgresql

--- a/kubernetes/redis-deploy.yml
+++ b/kubernetes/redis-deploy.yml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: redis
 spec:
   replicas: 1
   selector:
-    name: redis
+    matchLabels:
+      name: redis
   template:
     metadata:
       name: redis


### PR DESCRIPTION
Deployments use declarative configuration and have a simpler workflow (for most use cases, at least) for pushing updates than ReplicationController. It would be good to consider moving the sample k8s configurations over to this format.
