### PR TITLE
Store gitlab-workhorse & mail_room stdout/stderr log files in correct directory.

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -269,8 +269,8 @@ command=/usr/local/bin/gitlab-workhorse
 user=git
 autostart=true
 autorestart=true
-stdout_logfile=${GITLAB_INSTALL_DIR}/log/%(program_name)s.log
-stderr_logfile=${GITLAB_INSTALL_DIR}/log/%(program_name)s.log
+stdout_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
+stderr_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
 EOF
 
 # configure supervisord to start mail_room
@@ -283,8 +283,8 @@ command=bundle exec mail_room -c ${GITLAB_INSTALL_DIR}/config/mail_room.yml
 user=git
 autostart={{GITLAB_INCOMING_EMAIL_ENABLED}}
 autorestart=true
-stdout_logfile=${GITLAB_INSTALL_DIR}/log/%(program_name)s.log
-stderr_logfile=${GITLAB_INSTALL_DIR}/log/%(program_name)s.log
+stdout_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
+stderr_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
 EOF
 
 # configure supervisor to start sshd


### PR DESCRIPTION
Make the stdout/stderr log files captured by supervisord for gitlab-workhorse
and mail_room to be stored in the same directory as the other child
processes.
