### PR TITLE
Allow supervisord to capture unicorn's stdout/stderr.

### DIFF
--- a/assets/runtime/config/gitlabhq/unicorn.rb
+++ b/assets/runtime/config/gitlabhq/unicorn.rb
@@ -64,8 +64,8 @@ pid "{{GITLAB_INSTALL_DIR}}/tmp/pids/unicorn.pid"
 # By default, the Unicorn logger will write to stderr.
 # Additionally, some applications/frameworks log to stderr or stdout,
 # so prevent them from going to /dev/null when daemonized here:
-stderr_path "{{GITLAB_INSTALL_DIR}}/log/unicorn.stderr.log"
-stdout_path "{{GITLAB_INSTALL_DIR}}/log/unicorn.stdout.log"
+#stderr_path "{{GITLAB_INSTALL_DIR}}/log/unicorn.stderr.log"
+#stdout_path "{{GITLAB_INSTALL_DIR}}/log/unicorn.stdout.log"
 
 # combine Ruby 2.0.0dev or REE with "preload_app true" for memory savings
 # http://rubyenterpriseedition.com/faq.html#adapt_apps_for_cow


### PR DESCRIPTION
Supervisord is already configured to log stdout/stderr for unicorn, but
nothing was getting to it because it was being directed to a different
place due to this config. Allow supervisord to handle it so that it's in
the same directory as the other processes managed by supervisord.
