### PR TITLE
Fix link in Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This file only reflects the changes that are made in this image. Please refer to the upstream GitLab [CHANGELOG](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CHANGELOG) for the list of changes in GitLab.
+This file only reflects the changes that are made in this image. Please refer to the upstream GitLab [CHANGELOG](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CHANGELOG.md) for the list of changes in GitLab.
 
 **8.12.6**
 - gitlab: upgrade to CE v8.12.6


### PR DESCRIPTION
The Changelog file in the upstream GitLab is renamed to have `.md` suffix.