### PR TITLE
Adds TCP port registry exposure.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
-EXPOSE 22/tcp 80/tcp 443/tcp
+EXPOSE 22/tcp 80/tcp 443/tcp 5500/tcp
 
 VOLUME ["${GITLAB_DATA_DIR}", "${GITLAB_LOG_DIR}"]
 WORKDIR ${GITLAB_INSTALL_DIR}


### PR DESCRIPTION
# Description

TCP port for Registry feature is not being exposed on Dockerfile, so the service cannot be mapped to host's port.