### PR TITLE
Fix MySQL first run (a foreign key constraint fails)

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1294,6 +1294,13 @@ migrate_database() {
       ;;
   esac
 
+  if [[ -z ${COUNT} || ${COUNT} -eq 0 ]]; then
+    echo "Setting up GitLab for firstrun. Please be patient, this could take a while..."
+    exec_as_git force=yes bundle exec rake gitlab:setup \
+      ${GITLAB_ROOT_PASSWORD:+GITLAB_ROOT_PASSWORD=$GITLAB_ROOT_PASSWORD} \
+      ${GITLAB_ROOT_EMAIL:+GITLAB_ROOT_EMAIL=$GITLAB_ROOT_EMAIL} >/dev/null
+  fi
+
   # migrate database if the gitlab version has changed.
   CACHE_VERSION=
   [[ -f ${GITLAB_TEMP_DIR}/VERSION ]] && CACHE_VERSION=$(cat ${GITLAB_TEMP_DIR}/VERSION)
@@ -1331,13 +1338,6 @@ migrate_database() {
 
     echo "${GITLAB_VERSION}" > ${GITLAB_TEMP_DIR}/VERSION
     rm -rf ${GITLAB_TEMP_DIR}/GITLAB_RELATIVE_URL_ROOT # force cache cleanup
-  fi
-
-  if [[ -z ${COUNT} || ${COUNT} -eq 0 ]]; then
-    echo "Setting up GitLab for firstrun. Please be patient, this could take a while..."
-    exec_as_git force=yes bundle exec rake gitlab:setup \
-      ${GITLAB_ROOT_PASSWORD:+GITLAB_ROOT_PASSWORD=$GITLAB_ROOT_PASSWORD} \
-      ${GITLAB_ROOT_EMAIL:+GITLAB_ROOT_EMAIL=$GITLAB_ROOT_EMAIL} >/dev/null
   fi
 
   # clear cache if relative_url has changed.


### PR DESCRIPTION
Fixes an issue where starting a new MySQL based container would fail
due to foreign key constraints.

To avoid this problem, the order of steps is changed, so `gitlab:setup` runs before `db:migrate`.

```
gitlab_1  | Migrating database...
gitlab_1  | Setting up GitLab for firstrun. Please be patient, this could take a while...
gitlab_1  | gitlabhq_production already exists
gitlab_1  | rake aborted!
gitlab_1  | ActiveRecord::StatementInvalid: Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails: DROP TABLE `boards` CASCADE
...
gitlab_1  | /home/git/gitlab/lib/tasks/gitlab/setup.rake:17:in `setup_db'
gitlab_1  | /home/git/gitlab/lib/tasks/gitlab/setup.rake:4:in `block (2 levels) in <top (required)>'
...
gitlab_1  | Tasks: TOP => db:schema:load
gitlab_1  | (See full trace by running task with --trace)
gitlab_gitlab_1 exited with code 1
```

With this fix, it works correctly:

```
gitlab_1  | Setting up GitLab for firstrun. Please be patient, this could take a while...
gitlab_1  | gitlabhq_production already exists
gitlab_1  | Migrating database...
gitlab_1  | Clearing cache...
gitlab_1  | 2016-11-26 12:16:27,366 CRIT Supervisor running as root (no user in config file)
...
```