### PR TITLE
Add the ability to use x509 key and certificate in SAML options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+REGISTRY=sameersbn
+TAG:=$(shell cat VERSION)
+
 all: build
 
 help:
@@ -11,10 +14,10 @@ help:
 	@echo "   5. make purge        - stop and remove the container"
 
 build:
-	@docker build --tag=sameersbn/gitlab .
+	@docker build --tag=$(REGISTRY)/gitlab .
 
 release: build
-	@docker build --tag=sameersbn/gitlab:$(shell cat VERSION) .
+	@docker push $(REGISTRY)/gitlab:$(TAG)
 
 quickstart:
 	@echo "Starting postgresql container..."

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ For example, if your Client ID is `xxx` and the Client secret is `yyy`, then add
 
 GitLab can be configured to act as a SAML 2.0 Service Provider (SP). This allows GitLab to consume assertions from a SAML 2.0 Identity Provider (IdP) such as Microsoft ADFS to authenticate users. Please refer to the GitLab [documentation](http://doc.gitlab.com/ce/integration/saml.html).
 
-The following parameters have to be configured to enable SAML OAuth support in this image: `OAUTH_SAML_ASSERTION_CONSUMER_SERVICE_URL`, `OAUTH_SAML_IDP_CERT_FINGERPRINT`, `OAUTH_SAML_IDP_SSO_TARGET_URL`, `OAUTH_SAML_ISSUER` and `OAUTH_SAML_NAME_IDENTIFIER_FORMAT`.
+The following parameters have to be configured to enable SAML OAuth support in this image: `OAUTH_SAML_ASSERTION_CONSUMER_SERVICE_URL`, `OAUTH_SAML_IDP_CERT_FINGERPRINT`, `OAUTH_SAML_IDP_SSO_TARGET_URL`, `OAUTH_SAML_ISSUER` and `OAUTH_SAML_NAME_IDENTIFIER_FORMAT`, `OAUTH_SAML_PRIVATE_KEY`, and `OAUTH_SAML_CERTIFICATE`.
 
 You can also override the default "Sign in with" button label with `OAUTH_SAML_LABEL`.
 

--- a/README.md
+++ b/README.md
@@ -958,6 +958,9 @@ Below is the complete list of available options that can be used to customize yo
 | `OAUTH_SAML_ATTRIBUTE_STATEMENTS_NAME` | Map 'name' attribute in a SAMLResponse to entries in the OmniAuth info hash, No defaults. See [GitLab documentation](http://doc.gitlab.com/ce/integration/saml.html#attribute_statements) for more details. |
 | `OAUTH_SAML_ATTRIBUTE_STATEMENTS_FIRST_NAME` | Map 'first_name' attribute in a SAMLResponse to entries in the OmniAuth info hash, No defaults. See [GitLab documentation](http://doc.gitlab.com/ce/integration/saml.html#attribute_statements) for more details. |
 | `OAUTH_SAML_ATTRIBUTE_STATEMENTS_LAST_NAME` | Map 'last_name' attribute in a SAMLResponse to entries in the OmniAuth info hash, No defaults. See [GitLab documentation](http://doc.gitlab.com/ce/integration/saml.html#attribute_statements) for more details. |
+| `OAUTH_SAML_PRIVATE_KEY` | Provide gitlab a private key to use for secure saml requests and assertions. No default, and must be coupled with `OAUTH_SAML_CERTIFICATE` to take effect. See [ruby-saml](https://github.com/onelogin/ruby-saml#signing) for more details. |
+|
+| `OAUTH_SAML_CERTIFICATE` | Provide gitlab a public certificate to use for secure saml requests and assertions. No default, and must be coupled with `OAUTH_SAML_PRIVATE_KEY` to take effect. |
 | `OAUTH_CROWD_SERVER_URL` | Crowd server url. No defaults. |
 | `OAUTH_CROWD_APP_NAME` | Crowd server application name. No defaults. |
 | `OAUTH_CROWD_APP_PASSWORD` | Crowd server application password. No defaults. |

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -60,7 +60,7 @@ exec_as_git ./bin/install
 # remove unused repositories directory created by gitlab-shell install
 exec_as_git rm -rf ${GITLAB_HOME}/repositories
 
-echo "Downloading gitlab-workhorse v.${GITLAB_WORKHORSE_VERSION}..."
+echo "Downloading gitlab-workhorse v${GITLAB_WORKHORSE_VERSION}..."
 mkdir -p ${GITLAB_WORKHORSE_INSTALL_DIR}
 wget -cq ${GITLAB_WORKHORSE_URL}?ref=v${GITLAB_WORKHORSE_VERSION} -O ${GITLAB_BUILD_DIR}/gitlab-workhorse-${GITLAB_WORKHORSE_VERSION}.tar.gz
 tar xf ${GITLAB_BUILD_DIR}/gitlab-workhorse-${GITLAB_WORKHORSE_VERSION}.tar.gz --strip 1 -C ${GITLAB_WORKHORSE_INSTALL_DIR}

--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -403,6 +403,8 @@ production: &base
                   idp_cert_fingerprint: '{{OAUTH_SAML_IDP_CERT_FINGERPRINT}}',
                   idp_sso_target_url: '{{OAUTH_SAML_IDP_SSO_TARGET_URL}}',
                   issuer: '{{OAUTH_SAML_ISSUER}}',
+                  private_key: '{{OAUTH_SAML_PRIVATE_KEY}}',
+                  certificate: '{{OAUTH_SAML_CERTIFICATE}}',
                   attribute_statements: {
                     first_name: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_FIRST_NAME}}'],
                     last_name: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_LAST_NAME}}'],

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -562,7 +562,10 @@ gitlab_configure_oauth_saml() {
       OAUTH_SAML_ISSUER \
       OAUTH_SAML_NAME_IDENTIFIER_FORMAT \
       OAUTH_SAML_GROUPS_ATTRIBUTE \
-      OAUTH_SAML_EXTERNAL_GROUPS
+      OAUTH_SAML_EXTERNAL_GROUPS \
+      OAUTH_SAML_PRIVATE_KEY \
+      OAUTH_SAML_CERTIFICATE
+
     exec_as_git sed -i "/groups_attribute: '',/d" ${GITLAB_CONFIG}
     exec_as_git sed -i "/external_groups: \\[\\],/d" ${GITLAB_CONFIG}
     gitlab_configure_oauth_saml_attribute_statements


### PR DESCRIPTION
This enables the use of encrypted assertions and signed requests for IdPs that support these options if both options are included.