### PR TITLE
Add redis auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,11 +419,12 @@ The internal redis server has been removed from the image. Please use a [linked 
 
 The image can be configured to use an external redis server. The configuration should be specified using environment variables while starting the GitLab image.
 
-*Assuming that the redis server host is 192.168.1.100*
+*Assuming that the redis server host is 192.168.1.100, and configured to use authentication*
 
 ```bash
 docker run --name gitlab -it --rm \
     --env 'REDIS_HOST=192.168.1.100' --env 'REDIS_PORT=6379' \
+    --env 'REDIS_PASSWORD=p4ssw0rd' \
     sameersbn/gitlab:8.14.5
 ```
 

--- a/assets/runtime/config/gitlabhq/resque.yml
+++ b/assets/runtime/config/gitlabhq/resque.yml
@@ -14,7 +14,7 @@ test:
   url: redis://localhost:6379
 production:
   # Redis (single instance)
-  url: redis://{{REDIS_HOST}}:{{REDIS_PORT}}/{{REDIS_DB_NUMBER}}
+  url: redis://{{REDIS_PASSWORD}}{{REDIS_HOST}}:{{REDIS_PORT}}/{{REDIS_DB_NUMBER}}
   ##
   # Redis + Sentinel (for HA)
   #

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -241,8 +241,12 @@ gitlab_finalize_redis_parameters() {
 }
 
 gitlab_check_redis_connection() {
+  REDIS_FLAG=""
+  if [[ -n ${REDIS_PASSWORD} ]]; then
+    REDIS_FLAG="-a ${REDIS_PASSWORD}"
+  fi
   timeout=60
-  while ! redis-cli -h ${REDIS_HOST} -p ${REDIS_PORT} -n ${REDIS_DB_NUMBER} ping >/dev/null 2>&1
+  while ! redis-cli -h ${REDIS_HOST} ${REDIS_FLAG} -p ${REDIS_PORT} -n ${REDIS_DB_NUMBER} ping >/dev/null 2>&1
   do
     timeout=$(expr $timeout - 1)
     if [[ $timeout -eq 0 ]]; then
@@ -262,10 +266,15 @@ gitlab_configure_redis() {
   gitlab_finalize_redis_parameters
   gitlab_check_redis_connection
 
+  if [[ -n ${REDIS_PASSWORD} ]]; then
+    REDIS_PASSWORD=':'${REDIS_PASSWORD}'@'
+  fi
+
   update_template ${GITLAB_RESQUE_CONFIG} \
     REDIS_HOST \
     REDIS_PORT \
-    REDIS_DB_NUMBER
+    REDIS_DB_NUMBER \
+    REDIS_PASSWORD
 }
 
 gitlab_configure_gitlab_workhorse() {


### PR DESCRIPTION
This PR adds support for redis authentication through the REDIS_PASSWORD environment variable.

For a production-ready environment this is a requirement for us!