### PR TITLE
Fix typo in gitlab_ssl config

### DIFF
--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -24,7 +24,7 @@ upstream gitlab-workhorse {
   server localhost:8181 fail_timeout=0;
 }
 
-map $http_upgrade $connection_upgrade_gitlab {
+map $http_upgrade $connection_upgrade_gitlab_ssl {
     default upgrade;
     ''      close;
 }


### PR DESCRIPTION
Made a little typo in nginx ssl configuration . 


Closes #1032 