### PR TITLE
Use yarn to install JS dependencies

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -125,7 +125,7 @@ exec_as_git cp ${GITLAB_INSTALL_DIR}/config/gitlab.yml.example ${GITLAB_INSTALL_
 exec_as_git cp ${GITLAB_INSTALL_DIR}/config/database.yml.mysql ${GITLAB_INSTALL_DIR}/config/database.yml
 
 # Installs nodejs packages required to compile webpack
-npm install
+exec_as_git yarn install --production --pure-lockfile
 
 echo "Compiling assets. Please be patient, this could take a while..."
 #Adding webpack compile needed since 8.17


### PR DESCRIPTION
Since yarn is part of the image now, we should use it to install JS dependencies.