### PR TITLE
Fix faulty nginx config for pages

### DIFF
--- a/assets/runtime/config/nginx/gitlab-pages
+++ b/assets/runtime/config/nginx/gitlab-pages
@@ -3,7 +3,7 @@
 ## Pages serving host
 server {
   listen 0.0.0.0:80;
-  listen [::]:80 ipv6only=on;
+  listen [::]:80;
   ## Replace this with something like pages.gitlab.com
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};
   ## Individual nginx logs for GitLab pages

--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -8,7 +8,7 @@ server {
   ## to be served if you visit any address that your server responds to, eg.
   ## the ip address of the server (http://x.x.x.x/)
   listen 0.0.0.0:80;
-  listen [::]:80 ipv6only=on;
+  listen [::]:80;
 
   ## Replace this with something like pages.gitlab.com
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};

--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -32,8 +32,8 @@ server {
   ## Strong SSL Security
   ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
   ssl on;
-  ssl_certificate {{SSL_CERTIFICATE_PATH}};
-  ssl_certificate_key {{SSL_KEY_PATH}};
+  ssl_certificate {{SSL_PAGES_CERT_PATH}};
+  ssl_certificate_key {{SSL_PAGES_KEY_PATH}};
 
   # GitLab needs backwards compatible ciphers to retain compatibility with Java IDEs
   ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1022,6 +1022,7 @@ nginx_configure_pages(){
     echo "Configuring nginx::gitlab-pages..."
     if [[ ${GITLAB_PAGES_HTTPS} == true ]]; then
       update_template ${GITLAB_PAGES_NGINX_CONFIG} \
+        GITLAB_PORT \
         GITLAB_PAGES_DOMAIN \
         GITLAB_PAGES_PORT \
         GITLAB_LOG_DIR \


### PR DESCRIPTION
This will fix issues starting container when pages enabled with https support. Also will remove issues in some configurations where ipv6only will cause listen directive to be considered as duplicate by nginx.