### PR TITLE
Update readme for using postgresql container linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ We are now ready to start the GitLab application.
 
 ```bash
 docker run --name gitlab -d --link gitlab-mysql:mysql \
+    --env 'DB_ADAPTER=postgresql' \
     --volume /srv/docker/gitlab/gitlab:/home/git/data \
     sameersbn/gitlab:8.17.4
 ```


### PR DESCRIPTION
When following the readme I noticed that you need to set the db_adapter to be able to use container linking for Postgresql. Updated readme to reflect this.