### PR TITLE
Use Ruby 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM sameersbn/ubuntu:16.04.20190706
 LABEL maintainer="sameer@damagehead.com"
 
 ENV GITLAB_VERSION=11.0.2 \
-    RUBY_VERSION=2.3 \
+    RUBY_VERSION=2.4 \
     GOLANG_VERSION=1.10.3 \
     GITLAB_SHELL_VERSION=7.1.4 \
     GITLAB_WORKHORSE_VERSION=4.3.1 \


### PR DESCRIPTION
Hi,

the purpose of this PR is to try out GitLab with Ruby 2.4.

"It works for me". No failures so far.

![screenshot from 2017-04-04 12 19 14](https://cloud.githubusercontent.com/assets/28908/24652247/69f1a396-1931-11e7-906d-8e85264a0ed9.png)

As am not sure what's the official status is of upgrading to Ruby 2.4 I'd love to hear more success/failure stories :grinning: :green_heart: 

Kind regards,
  Peter
