### PR TITLE
Add tutorial for Synology setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
     - [Shell Access](#shell-access)
 - [Features](#features)
  - [Container Registry](docs/container_registry.md)
+- [Synology](#synology)
 - [References](#references)
 
 # Introduction
@@ -1242,6 +1243,10 @@ For debugging and maintenance purposes you may want access the containers shell.
 ```bash
 docker exec -it gitlab bash
 ```
+
+# Synology
+
+To setup GitLab with Synology DSM follow this [tutorial](https://github.com/cpoetter/Synology-GitLab-Setup).
 
 # References
 


### PR DESCRIPTION
Synology’s basic GitLab package is based on this Docker. But GitLab Runner or GitLab Container Registry are not available through the Package Center. Therefore I created a tutorial. Because this repository was my first location to look for an explanation how to set it up, I would like to link it in the ReadMe.