### PR TITLE
Bring registry nginx config on-par with others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+language: bash
+services:
+  - docker
+env:
+  matrix:
+    - GITLAB_EDITION=ce DOCKER_TAG=latest DOCKER_SUFFIX=
+    - GITLAB_EDITION=ee DOCKER_TAG=ee DOCKER_SUFFIX=-ee
+  global:
+    - DOCKER_CACHE_DIR=/home/travis/docker/
+    - secure: b5LCs3GtIydwINq6mByb/YOT1Ypj7nNAAD3uEM6fdRvmypUV3ydiPt+OGcdYsmOWk5C4ArLXrV7duHP2Se/nmzWVI/joRLZPeJy/ZPIBZ5akFEvBYkYAKoeEwhGHq0JAFgTIYHKWideupQJsofSyMjKdXjPWrYEPlUigYJSDnOXbU6WEhV0r50IEnDulASoyyiZrWMVep7Zoth0eGZmMdLP7HA5QrflqBUMqftNexuIdJvAMJAnabVv0uef61sxW/FP5AVKssxd4/Luvd46J/4ZckuK4QYAzOfX0S0Kla9rcqyyV/s0LDzfH/FIsp2/WN0Czyepp1Lga+csuy27omaC0Ufv2JNVEKZ7lCH0/Rax4A0lW1FsjtOJyFQVgvhtfjd9NSegDXQNx/D8VqaVJ5wbzCWrHHA8dVRS3Qlxhcu+WEA/56vajlb+Ca1LU3VS6s7q2ALVWjyXefamg9dxp4W+o3w9YxdHhSa5T2zJmSL/zCpYlzbJS8e3xSYzyv6XE5YcffdUuxeYBqAXITaLGHZwJZgwzYpCJIXUJyp9eKbx94Hhku5GTTWrV1ZAMRcKv3pSwiyP4TYUAQKomh5p42em83eo1jKqbcb2FlB1gDreeEf43FIV2t2yBOrZXparzndXwn1e9GjaCU3iYP+Bsx5aIhmtBZemyRQAZKMkZ4Zo=
+    - secure: MwrJfvOJBLrclYveSa3W6ZIq+pgfKh9e0O+Ma5bY2MTykV6yAXjVyvHwKp8TnKHOLRPW+bynkqEhbpA33OtlGNOS1V53euUegoRJY8OoXjMPW50JuIFzUDaMiOjYCNcbcAayPqOBTkKqbM8EJtkjpENiePCYO9ptpmj2r8aIp7XyExt36HNgZoBxwr9BR2qCT+6Q/JXqHsqgDeG/BjKk6TVcx5LdkFRoBk1DkPU2zsXfIEQGRUAd2zoXJcZjt0f2ojjf3fnshWgRd5qFdM9PKOuKr+IW7aGjitScaUQS5OwwiG8oxJx93Obl/XiGyS4+Irl6AYK1fWm9m30si62OpIP8dz/BS75+4+BxZlYwQs5LR5uujrS86smfBjMaYYxYhnWgsPwbxm966WovrAhhyTe/oiY+wIAFnsMzLpKd+ORD02F0N9QZk7RJLMlJKAkIz5LrJHZfKS1/USWdCaKPxwNKha+Ukyg/VR6qfbQjn8dVIDVvOjcsdgT3/EmlW3CCN4TvZwMGNkbJKIodazzu4nvLiIfT3Q6EcTn5BWtYLgGroCkRU7cKBamSDbzEPbBeWYKV3bDwPBGknyFTCslNKob3pZyS44WbMOH7OCDSTf+MAblghiDbKwKi2IahyCnv9r0DqA7Ymj2i6/4TlqyWaPbbTnX2SqvvwxQdzAXW68M=
+before_install:
+  - if [ -f ${DOCKER_CACHE_DIR}/cache${DOCKER_SUFFIX}.tgz ]; then gunzip -c ${DOCKER_CACHE_DIR}/cache${DOCKER_SUFFIX}.tgz | docker load; fi
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+script:
+  - docker build --build-arg GITLAB_EDITION=${GITLAB_EDITION} -t fmauneko/gitlab:${DOCKER_TAG} .
+  - mkdir -p ${DOCKER_CACHE_DIR}; docker save $(docker history -q fmauneko/gitlab:${DOCKER_TAG} | grep -v '<missing>') | gzip > ${DOCKER_CACHE_DIR}/cache${DOCKER_SUFFIX}.tgz
+
+after_success:
+  - docker tag fmauneko/gitlab:${DOCKER_TAG} fmauneko/gitlab:$(cat VERSION)${DOCKER_SUFFIX}
+  - docker push fmauneko/gitlab:${DOCKER_TAG}
+  - docker push fmauneko/gitlab:$(cat VERSION)${DOCKER_SUFFIX}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 COPY assets/build/ ${GITLAB_BUILD_DIR}/
+ARG GITLAB_EDITION=ce
 RUN bash ${GITLAB_BUILD_DIR}/install.sh
 
 COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,18 @@ help:
 	@echo "   5. make purge        - stop and remove the container"
 
 build:
-	@docker build --tag=sameersbn/gitlab .
+	@docker build -t fmauneko/gitlab:latest .
+	@docker build --build-arg GITLAB_EDITION=ee -t fmauneko/gitlab:ee .
 
 release: build
-	@docker build --tag=sameersbn/gitlab:$(shell cat VERSION) .
+	@docker tag fmauneko/gitlab:latest fmauneko/gitlab:$(shell cat VERSION)
+	@docker tag fmauneko/gitlab:ee fmauneko/gitlab:$(shell cat VERSION)-ee
+
+push: release
+	@docker push fmauneko/gitlab:latest
+	@docker push fmauneko/gitlab:$(shell cat VERSION)
+	@docker push fmauneko/gitlab:ee
+	@docker push fmauneko/gitlab:$(shell cat VERSION)-ee
 
 quickstart:
 	@echo "Starting postgresql container..."

--- a/README.md
+++ b/README.md
@@ -135,10 +135,18 @@ You can also pull the `latest` tag which is built from the repository *HEAD*
 docker pull sameersbn/gitlab:latest
 ```
 
-Alternatively you can build the image locally.
+Alternatively you can build the images locally.
+
+## Community Edition
 
 ```bash
 docker build -t sameersbn/gitlab github.com/sameersbn/docker-gitlab
+```
+
+## Enterprise Edition
+
+```bash
+docker build --build-arg GITLAB_EDITION=ee -t sameersbn/gitlab-ee github.com/sameersbn/docker-gitlab
 ```
 
 # Quick Start

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-GITLAB_CLONE_URL=https://gitlab.com/gitlab-org/gitlab-ce.git
+GITLAB_EDITION=${GITLAB_EDITION:-ce}
+
+# if we're using the enterprise edition suffix the version with -ee
+if [ x"${GITLAB_EDITION}" = x"ee" ] ; then
+	GITLAB_VERSION="${GITLAB_VERSION}-ee"
+fi
+
+GITLAB_CLONE_URL=https://gitlab.com/gitlab-org/gitlab-${GITLAB_EDITION}.git
 GITLAB_SHELL_URL=https://gitlab.com/gitlab-org/gitlab-shell/-/archive/v${GITLAB_SHELL_VERSION}/gitlab-shell-v${GITLAB_SHELL_VERSION}.tar.bz2
 GITLAB_WORKHORSE_URL=https://gitlab.com/gitlab-org/gitlab-workhorse.git
 GITLAB_PAGES_URL=https://gitlab.com/gitlab-org/gitlab-pages.git
@@ -64,7 +71,7 @@ exec_as_git git config --global gc.auto 0
 exec_as_git git config --global repack.writeBitmaps true
 
 # shallow clone gitlab-ce
-echo "Cloning gitlab-ce v.${GITLAB_VERSION}..."
+echo "Cloning gitlab-${GITLAB_EDITION} v.${GITLAB_VERSION}..."
 exec_as_git git clone -q -b v${GITLAB_VERSION} --depth 1 ${GITLAB_CLONE_URL} ${GITLAB_INSTALL_DIR}
 
 GITLAB_SHELL_VERSION=${GITLAB_SHELL_VERSION:-$(cat ${GITLAB_INSTALL_DIR}/GITLAB_SHELL_VERSION)}

--- a/assets/runtime/config/nginx/gitlab-registry
+++ b/assets/runtime/config/nginx/gitlab-registry
@@ -5,37 +5,14 @@
 ##         configuration         ##
 ###################################
 
-## Redirects all HTTP traffic to the HTTPS host
 server {
-  listen *:80;
-  server_name  {{GITLAB_REGISTRY_HOST}};
-  server_tokens off; ## Don't show the nginx version number, a security best practice
-  return 301 https://$http_host:$request_uri;
-  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_access.log;
-  error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_error.log;
-}
-
-server {
-  # If a different port is specified in https://gitlab.com/gitlab-org/gitlab-ce/blob/8-8-stable/config/gitlab.yml.example#L182,
-  # it should be declared here as well
-  listen *:{{GITLAB_REGISTRY_PORT}} ssl http2;
+  listen 0.0.0.0:80;
+  listen [::]:80 ipv6only=on;
   server_name  {{GITLAB_REGISTRY_HOST}};
   server_tokens off; ## Don't show the nginx version number, a security best practice
 
   client_max_body_size 0;
   chunked_transfer_encoding on;
-
-  ## Strong SSL Security
-  ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
-  ssl on;
-  ssl_certificate {{SSL_REGISTRY_CERT_PATH}};
-  ssl_certificate_key {{SSL_REGISTRY_KEY_PATH}};
-
-  ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
-  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-  ssl_prefer_server_ciphers on;
-  ssl_session_cache  builtin:1000  shared:SSL:10m;
-  ssl_session_timeout  5m;
 
   access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_access.log;
   error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_error.log;

--- a/assets/runtime/config/nginx/gitlab-registry-ssl
+++ b/assets/runtime/config/nginx/gitlab-registry-ssl
@@ -1,0 +1,55 @@
+## Lines starting with two hashes (##) are comments with information.
+## Lines starting with one hash (#) are configuration parameters that can be uncommented.
+##
+###################################
+##         configuration         ##
+###################################
+
+## Redirects all HTTP traffic to the HTTPS host
+server {
+  listen 0.0.0.0:80;
+  listen [::]:80 ipv6only=on;
+  server_name  {{GITLAB_REGISTRY_HOST}};
+  server_tokens off; ## Don't show the nginx version number, a security best practice
+  return 301 https://$http_host:$request_uri;
+  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_access.log;
+  error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_error.log;
+}
+
+server {
+  # If a different port is specified in https://gitlab.com/gitlab-org/gitlab-ce/blob/8-8-stable/config/gitlab.yml.example#L182,
+  # it should be declared here as well
+  listen 0.0.0.0:{{GITLAB_REGISTRY_PORT}} ssl http2;
+  listen [::]:{{GITLAB_REGISTRY_PORT}} ipv6only=on ssl http2;
+  server_name  {{GITLAB_REGISTRY_HOST}};
+  server_tokens off; ## Don't show the nginx version number, a security best practice
+
+  client_max_body_size 0;
+  chunked_transfer_encoding on;
+
+  ## Strong SSL Security
+  ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
+  ssl on;
+  ssl_certificate {{SSL_REGISTRY_CERT_PATH}};
+  ssl_certificate_key {{SSL_REGISTRY_KEY_PATH}};
+
+  ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache  builtin:1000  shared:SSL:10m;
+  ssl_session_timeout  5m;
+
+  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_access.log;
+  error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_registry_error.log;
+
+  location / {
+    proxy_set_header  Host              $http_host;   # required for docker client's sake
+    proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+    proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_read_timeout                  900;
+
+    proxy_pass          {{GITLAB_REGISTRY_API_URL}};
+  }
+
+}

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1180,17 +1180,26 @@ nginx_configure_gitlab_ci() {
   fi
 }
 
+nginx_configure_gitlab_registry_ssl() {
+  if [[ -f ${SSL_REGISTRY_CERT_PATH} && -f ${SSL_REGISTRY_KEY_PATH} ]]; then
+    echo "Configuring nginx::gitlab-registry::ssl..."
+    update_template ${GITLAB_REGISTRY_NGINX_CONFIG} \
+      SSL_REGISTRY_KEY_PATH \
+      SSL_REGISTRY_CERT_PATH
+  fi
+}
+
 nginx_configure_gitlab_registry() {
-  if [[ $GITLAB_REGISTRY_ENABLED == true && -f ${SSL_REGISTRY_CERT_PATH} && -f ${SSL_REGISTRY_KEY_PATH} ]]; then
+  if [[ $GITLAB_REGISTRY_ENABLED == true ]]; then
     echo "Configuring nginx::gitlab-registry..."
     update_template ${GITLAB_REGISTRY_NGINX_CONFIG} \
       GITLAB_LOG_DIR \
       GITLAB_REGISTRY_PORT \
       GITLAB_REGISTRY_HOST \
-      GITLAB_REGISTRY_API_URL \
-      SSL_REGISTRY_KEY_PATH \
-      SSL_REGISTRY_CERT_PATH
+      GITLAB_REGISTRY_API_URL
   fi
+
+  nginx_configure_gitlab_registry_ssl
 }
 
 nginx_configure_pages(){
@@ -1489,12 +1498,14 @@ install_configuration_templates() {
     install_template root: nginx/gitlab_ci ${GITLAB_CI_NGINX_CONFIG}
   fi
 
+  ## ${GITLAB_REGISTRY_NGINX_CONFIG}
   if [[ ${GITLAB_REGISTRY_ENABLED} == true ]]; then
     if [[ -f ${SSL_REGISTRY_CERT_PATH} && -f ${SSL_REGISTRY_KEY_PATH} ]]; then
-      install_template root: nginx/gitlab-registry ${GITLAB_REGISTRY_NGINX_CONFIG}
+      install_template root: nginx/gitlab-registry-ssl ${GITLAB_REGISTRY_NGINX_CONFIG}
     else
       echo "SSL key and certificates for Registry were not found"
       echo "Assuming that the Registry is running behind a HTTPS enabled load balancer."
+      install_template root: nginx/gitlab-registry ${GITLAB_REGISTRY_NGINX_CONFIG}
     fi
   fi
 


### PR DESCRIPTION
Hello,

Here's a fix for allowing access to the registry behind a reverse proxy.
Like for the other services, if there's no SSL certificates, we just serve it over HTTP instead of HTTPS (Otherwise, we get an infinite redirection loop)

I based it on how it was done for the main service, and the Pages service.

Have a good day !