### PR TITLE
Match upstream pipeline schedule worker cron

### DIFF
--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -193,7 +193,7 @@ production: &base
       cron: "0 * * * *"
     # Execute scheduled triggers
     pipeline_schedule_worker:
-      cron: "0 */12 * * *"
+      cron: "19 * * * *"
     # Remove expired build artifacts
     expire_build_artifacts_worker:
       cron: "50 * * * *"


### PR DESCRIPTION
Since Gitlab 9.2 we have [pipeline schedules](https://about.gitlab.com/2017/05/22/gitlab-9-2-released/#pipeline-schedules). The [upstream configuration](https://github.com/gitlabhq/gitlabhq/blob/437bb9282c90ac0ac8c3c87386b3220c33d2b4b4/config/gitlab.yml.example#L183-L185) triggers the pipeline-schedule-worker every our, not once every 12 hours.

Updated `gitlab.yml` to reflect this.