### PR TITLE
fix hash link

### DIFF
--- a/docs/container_registry.md
+++ b/docs/container_registry.md
@@ -334,7 +334,7 @@ docker run --name gitlab -it --rm [OPTIONS] \
 ```
 
 - **Step 4**: Create a certs folder
-Create an authentication certificate with [Generating certificate for authentication with the registry](#Generating-certificate-for-authentication-with-the-registry).
+Create an authentication certificate with [Generating certificate for authentication with the registry](#generating-certificate-for-authentication-with-the-registry).
 
 - **Step 5**: Create an registry instance
 


### PR DESCRIPTION
uppercase hash link is not active at chrome(version 58.0.3029.110)