### PR TITLE
Fix missing install_template for Gitaly

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1368,6 +1368,10 @@ install_configuration_templates() {
       echo "Assuming that the Registry is running behind a HTTPS enabled load balancer."
     fi
   fi
+
+  if [[ ${GITALY_ENABLED} == true ]]; then
+    install_template ${GITLAB_USER}: gitaly/config.toml ${GITLAB_GITALY_CONFIG}
+  fi
 }
 
 configure_gitlab() {


### PR DESCRIPTION
This part was missing to use Gitaly correctly. Through this users weren't able to use the git commands over http/https.

Closes #1270 