### PR TITLE
Regenerate secrets on container startup

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -156,6 +156,9 @@ exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VAL
 # remove auto generated ${GITLAB_DATA_DIR}/config/secrets.yml
 rm -rf ${GITLAB_DATA_DIR}/config/secrets.yml
 
+# remove gitlab shell and workhorse secrets
+rm -f ${GITLAB_INSTALL_DIR}/.gitlab_shell_secret ${GITLAB_INSTALL_DIR}/.gitlab_workhorse_secret
+
 exec_as_git mkdir -p ${GITLAB_INSTALL_DIR}/tmp/pids/ ${GITLAB_INSTALL_DIR}/tmp/sockets/
 chmod -R u+rwX ${GITLAB_INSTALL_DIR}/tmp
 

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -710,6 +710,18 @@ gitlab_configure_secrets() {
   GITLAB_SECRETS_DB_KEY_BASE \
   GITLAB_SECRETS_SECRET_KEY_BASE \
   GITLAB_SECRETS_OTP_KEY_BASE
+
+  local shell_secret="${GITLAB_INSTALL_DIR}/.gitlab_shell_secret"
+  if [[ ! -f "${shell_secret}" ]]; then
+    exec_as_git openssl rand -hex -out "${shell_secret}" 16
+    chmod 600 "${shell_secret}"
+  fi
+
+  local workhorse_secret="${GITLAB_INSTALL_DIR}/.gitlab_workhorse_secret"
+  if [[ ! -f "${workhorse_secret}" ]]; then
+    exec_as_git openssl rand -base64 -out "${workhorse_secret}" 32
+    chmod 600 "${workhorse_secret}"
+  fi
 }
 
 gitlab_configure_sidekiq() {


### PR DESCRIPTION
The gitlab container includes the files ${GITLAB_INSTALL_DIR}/.gitlab_{shell,workhorse}_secret .
However, these must be kept secret and should therefore not be included in the image.

I've found at least two possible attacks: The internal API intended only for use by the gitlab-shell can be accessed using the shell secret leading to information disclosure and bypass of 2FA.

Fixing this requires deleting both files during the container build process and recreating them on container startup. Although gitlab will also create both files automatically, there seems to be a race condition that from time to time breaks the gitlab-shell on the first startup of the container. The commit therefore calls `openssl rand` on first start to generate the secrects. The type of secret mirrors that from gitlab.