### PR TITLE
Remove explicit gettext:compile

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -164,8 +164,6 @@ exec_as_git cp ${GITLAB_INSTALL_DIR}/config/database.yml.mysql ${GITLAB_INSTALL_
 # Installs nodejs packages required to compile webpack
 exec_as_git yarn install --production --pure-lockfile
 
-exec_as_git bundle exec rake gettext:compile SKIP_STORAGE_VALIDATION=true
-
 echo "Compiling assets. Please be patient, this could take a while..."
 exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true
 


### PR DESCRIPTION
For this MR #1327  is required. 

This is not needed anymore it got fixed by the upstream.

https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/13122/diffs
Signed-off-by: solidnerd <niclas@mietz.io>