### PR TITLE
fix possible values for ldap-encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,8 +952,8 @@ Below is the complete list of available options that can be used to customize yo
 | `LDAP_HOST` | LDAP Host |
 | `LDAP_PORT` | LDAP Port. Defaults to `389` |
 | `LDAP_UID` | LDAP UID. Defaults to `sAMAccountName` |
-| `LDAP_METHOD` | LDAP method, Possible values are `ssl`, `tls` and `plain`. Defaults to `plain` |
-| `LDAP_VERIFY_SSL` | LDAP verify ssl certificate for installations that are using `start_tls` or `simple_tls`. Defaults to `true` |
+| `LDAP_METHOD` | LDAP method, Possible values are `simple_tls`, `start_tls` and `plain`. Defaults to `plain` |
+| `LDAP_VERIFY_SSL` | LDAP verify ssl certificate for installations that are using `LDAP_METHOD: 'simple_tls'` or `LDAP_METHOD: 'start_tls'`. Defaults to `true` |
 | `LDAP_BIND_DN` | No default. |
 | `LDAP_PASS` | LDAP password |
 | `LDAP_TIMEOUT` | Timeout, in seconds, for LDAP queries. Defaults to `10`. |

--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -264,7 +264,7 @@ production: &base
         host: '{{LDAP_HOST}}'
         port: {{LDAP_PORT}}
         uid: '{{LDAP_UID}}'
-        encryption: '{{LDAP_METHOD}}' # "tls" or "ssl" or "plain"
+        encryption: '{{LDAP_METHOD}}' # "start_tls" or "simple_tls" or "plain"
         verify_certificates: '{{LDAP_VERIFY_SSL}}'
         bind_dn: '{{LDAP_BIND_DN}}'
         password: '{{LDAP_PASS}}'


### PR DESCRIPTION
According to the [docu](https://docs.gitlab.com/ee/administration/auth/ldap.html#configuration) the possible values for the encrypted ldap-connection did change.

So this image-docu needs to be updated.