### PR TITLE
Add generic omniauth oauth2 suport

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,14 @@ Once you have the Client ID, Client secret and Tenant ID generated, configure th
 
 For example, if your Client ID is `xxx`, the Client secret is `yyy` and the Tenant ID is `zzz`, then adding `--env 'OAUTH_AZURE_API_KEY=xxx' --env 'OAUTH_AZURE_API_SECRET=yyy' --env 'OAUTH_AZURE_TENANT_ID=zzz'` to the docker run command enables support for Microsoft Azure OAuth.
 
+#### Generic OAuth2 OmniAuth
+
+To enable the Generic OAuth2 OmniAuth provider you must register your application with your provider.And you need to confirm OAuth2 provider site,Userinfo URL,Authorize URL,Token URL and the structure of the response of UserInfo.
+
+At least you need to configure the following environment variables `OAUTH_GENERIC_CLIENT_ID`, `OAUTH_GENERIC_CLIENT_SECRET`, `OAUTH_GENERIC_SITE`, `OAUTH_GENERIC_USER_INFO_URL`, `OAUTH_GENERIC_AUTHORIZE_URL`, `OAUTH_GENERIC_TOKEN_URL`, `OAUTH_GENERIC_ROOT_PATH`, `OAUTH_GENERIC_ID_PATH`, `OAUTH_GENERIC_USER_NAME` and `OAUTH_GENERIC_USER_EMAIL`.
+
+See [GitLab documentation](https://docs.gitlab.com/ee/integration/oauth2_generic.html#sign-into-gitlab-with-almost-any-oauth2-provider) and [Omniauth-oauth2-generic documentation](https://gitlab.com/satorix/omniauth-oauth2-generic) for more details.
+
 ### External Issue Trackers
 
 Since version `7.10.0` support for external issue trackers can be enabled in the "Service Templates" section of the settings panel.
@@ -1018,6 +1026,24 @@ Below is the complete list of available options that can be used to customize yo
 | `OAUTH_AZURE_API_KEY` | Azure Client ID. No defaults. |
 | `OAUTH_AZURE_API_SECRET` | Azure Client secret. No defaults. |
 | `OAUTH_AZURE_TENANT_ID` | Azure Tenant ID. No defaults. |
+| `OAUTH_GENERIC_CLIENT_ID` | Your own OAuth2 Client ID. No defaults. |
+| `OAUTH_GENERIC_CLIENT_SECRET` | Your own OAuth2 Client secret. No defaults. |
+| `OAUTH_GENERIC_SITE` | The URL for your OAuth 2 server(eg. https://your_oauth_server).Including port if necessary. No defaults. |
+| `OAUTH_GENERIC_USER_INFO_URL` | The endpoint on your OAuth 2 server that provides user info for the current user. No defaults. |
+| `OAUTH_GENERIC_AUTHORIZE_URL` | The authorization endpoint for your OAuth server. No defaults. |
+| `OAUTH_GENERIC_TOKEN_URL` | The token request endpoint for your OAuth server. No defaults. |
+| `OAUTH_GENERIC_ROOT_PATH` | An Array containing each key in the path to the node that contains the user attributes (i.e. `['data', 'attributes']` for a JsonAPI-formatted response).You need to set value like `data','attributes','user`. No defaults. |
+| `OAUTH_GENERIC_ID_PATH` | The name or path to the user ID (i.e. `['data', 'id']`).  Scalars are considered relative to `root_path`, Arrays are absolute paths. You need to set value like `data','attribute','id`. No defaults. |
+| `OAUTH_GENERIC_USER_NAME` | Scalars are treated as relative (i.e. 'username' would point to response`['data']['attributes']['username']`, given a root_path of `['data', 'attributes']`). Must needed. No defaults. |
+| `OAUTH_GENERIC_USER_EMAIL` | Arrays are treated as absolute paths (i.e. `['included', 'contacts', 0, 'email']` would point to response`['included']['contacts'][0]['email']`, regardless of root_path). Must needed. No defaults. |
+| `OAUTH_GENERIC_USER_NICKNAME` | User Nickname. No defaults. |
+| `OAUTH_GENERIC_USER_FIRST_NAME` | User's First Name. No defaults. |
+| `OAUTH_GENERIC_USER_LAST_NAME` | User's Last Name. No defaults. |
+| `OAUTH_GENERIC_USER_LOCATION` | User's Location. No defaults. |
+| `OAUTH_GENERIC_USER_DESC` | User's Description. No defaults. |
+| `OAUTH_GENERIC_USER_IMAGE` | User's Image. No defaults. |
+| `OAUTH_GENERIC_USER_PHONE` | User's Phone number. No defaults. |
+| `OAUTH_GENERIC_USER_URLS` | User's URL. No defaults. |
 | `GITLAB_GRAVATAR_ENABLED` | Enables gravatar integration. Defaults to `true`. |
 | `GITLAB_GRAVATAR_HTTP_URL` | Sets a custom gravatar url. Defaults to `http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon`. This can be used for [Libravatar integration](http://doc.gitlab.com/ce/customization/libravatar.html). |
 | `GITLAB_GRAVATAR_HTTPS_URL` | Same as above, but for https. Defaults to `https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon`. |

--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -461,6 +461,33 @@ production: &base
             client_id: '{{OAUTH_AZURE_API_KEY}}',
             client_secret: '{{OAUTH_AZURE_API_SECRET}}',
             tenant_id: '{{OAUTH_AZURE_TENANT_ID}}' } }
+      - { name: 'oauth2_generic',
+          args: {
+            client_id: '{{OAUTH_GENERIC_CLIENT_ID}}',
+            client_secret: '{{OAUTH_GENERIC_CLIENT_SECRET}}',
+            client_options: {
+              site: '{{OAUTH_GENERIC_SITE}}',
+              user_info_url: '{{OAUTH_GENERIC_USER_INFO_URL}}',
+              authorize_url: '{{OAUTH_GENERIC_AUTHORIZE_URL}}',
+              token_url: '{{OAUTH_GENERIC_TOKEN_URL}}'},
+            user_response_structure: {
+              root_path: ['{{OAUTH_GENERIC_ROOT_PATH}}'],
+              id_path: ['{{OAUTH_GENERIC_ID_PATH}}'],
+              attributes: {
+                name: '{{OAUTH_GENERIC_USER_NAME}}',
+                email: '{{OAUTH_GENERIC_USER_EMAIL}}',
+                nickname: '{{OAUTH_GENERIC_USER_NICKNAME}}',
+                first_name: '{{OAUTH_GENERIC_USER_FIRST_NAME}}',
+                last_name: '{{OAUTH_GENERIC_USER_LAST_NAME}}',
+                location: '{{OAUTH_GENERIC_USER_LOCATION}}',
+                descriptioin: '{{OAUTH_GENERIC_USER_DESC}}',
+                image: '{{OAUTH_GENERIC_USER_IMAGE}}',
+                phone: '{{OAUTH_GENERIC_USER_PHONE}}',
+                urls: '{{OAUTH_GENERIC_USER_URLS}}'
+                },
+              },
+            redirect_url: '{{OAUTH_GENERIC_REDIRECT_URL}}'
+            }}
 
     # SSO maximum session duration in seconds. Defaults to CAS default of 8 hours.
     # cas3:

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -662,6 +662,38 @@ gitlab_configure_oauth_azure() {
   fi
 }
 
+gitlab_configure_oauth_generic(){
+  if [[ -n ${OAUTH_GENERIC_CLIENT_ID} && \
+        -n ${OAUTH_GENERIC_CLIENT_SECRET} && \
+        -n ${OAUTH_GENERIC_SITE} && \
+        -n ${OAUTH_GENERIC_USER_INFO_URL} && \
+        -n ${OAUTH_GENERIC_AUTHORIZE_URL} && \
+        -n ${OAUTH_GENERIC_TOKEN_URL} ]]; then
+    echo "Configuring gitlab::oauth::generic"
+    OAUTH_ENABLED=${OAUTH_ENABLED:-true}
+    update_template ${GITLAB_CONFIG} \
+    OAUTH_GENERIC_CLIENT_ID \
+    OAUTH_GENERIC_CLIENT_SECRET \
+    OAUTH_GENERIC_SITE \
+    OAUTH_GENERIC_USER_INFO_URL \
+    OAUTH_GENERIC_AUTHORIZE_URL \
+    OAUTH_GENERIC_TOKEN_URL \
+    OAUTH_GENERIC_ROOT_PATH \
+    OAUTH_GENERIC_ID_PATH \
+    OAUTH_GENERIC_USER_NAME \
+    OAUTH_GENERIC_USER_EMAIL \
+    OAUTH_GENERIC_USER_NICKNAME \
+    OAUTH_GENERIC_USER_FIRST_NAME \
+    OAUTH_GENERIC_USER_LAST_NAME \
+    OAUTH_GENERIC_USER_LOCATION \
+    OAUTH_GENERIC_USER_DESC \
+    OAUTH_GENERIC_USER_IMAGE \
+    OAUTH_GENERIC_USER_PHONE \
+    OAUTH_GENERIC_USER_URLS \
+    OAUTH_GENERIC_REDIRECT_URL
+  fi
+}
+
 gitlab_configure_oauth() {
   echo "Configuring gitlab::oauth..."
 
@@ -677,6 +709,7 @@ gitlab_configure_oauth() {
   gitlab_configure_oauth_crowd
   gitlab_configure_oauth_auth0
   gitlab_configure_oauth_azure
+  gitlab_configure_oauth_generic
 
   OAUTH_ENABLED=${OAUTH_ENABLED:-false}
   update_template ${GITLAB_CONFIG} \
@@ -688,7 +721,7 @@ gitlab_configure_oauth() {
     OAUTH_EXTERNAL_PROVIDERS
 
   case ${OAUTH_AUTO_SIGN_IN_WITH_PROVIDER} in
-    cas3|google_oauth2|facebook|twitter|github|gitlab|bitbucket|saml|crowd|azure_oauth2)
+    cas3|google_oauth2|facebook|twitter|github|gitlab|bitbucket|saml|crowd|azure_oauth2|oauth2_generic)
       update_template ${GITLAB_CONFIG} OAUTH_AUTO_SIGN_IN_WITH_PROVIDER
       ;;
     *)


### PR DESCRIPTION
We wanted Single Sign On to our services and Gitlab for users and also need deploy quick. I refer the Document of Gitlab and add this feature.It allow user to configure the environment to enable generic omniauth oauth2.