### PR TITLE
Add support for building the enterprise edition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E1DD270288B4E60
  && rm -rf /var/lib/apt/lists/*
 
 COPY assets/build/ ${GITLAB_BUILD_DIR}/
+ARG GITLAB_EDITION=ce
 RUN bash ${GITLAB_BUILD_DIR}/install.sh
 
 COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/

--- a/README.md
+++ b/README.md
@@ -135,10 +135,18 @@ You can also pull the `latest` tag which is built from the repository *HEAD*
 docker pull sameersbn/gitlab:latest
 ```
 
-Alternatively you can build the image locally.
+Alternatively you can build the images locally.
+
+## Community Edition
 
 ```bash
 docker build -t sameersbn/gitlab github.com/sameersbn/docker-gitlab
+```
+
+## Enterprise Edition
+
+```bash
+docker build --build-arg GITLAB_EDITION=ee -t sameersbn/gitlab-ee github.com/sameersbn/docker-gitlab
 ```
 
 # Quick Start

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-GITLAB_CLONE_URL=https://gitlab.com/gitlab-org/gitlab-ce.git
+GITLAB_EDITION=${GITLAB_EDITION:-ce}
+
+# if we're using the enterprise edition suffix the version with -ee
+if [ x"${GITLAB_EDITION}" = x"ee" ] ; then
+	GITLAB_VERSION="${GITLAB_VERSION}-ee"
+fi
+
+GITLAB_CLONE_URL=https://gitlab.com/gitlab-org/gitlab-${GITLAB_EDITION}.git
 GITLAB_SHELL_URL=https://gitlab.com/gitlab-org/gitlab-shell/repository/archive.tar.gz
 GITLAB_WORKHORSE_URL=https://gitlab.com/gitlab-org/gitlab-workhorse.git
 GITLAB_PAGES_URL=https://gitlab.com/gitlab-org/gitlab-pages.git
@@ -63,7 +70,7 @@ exec_as_git git config --global gc.auto 0
 exec_as_git git config --global repack.writeBitmaps true
 
 # shallow clone gitlab-ce
-echo "Cloning gitlab-ce v.${GITLAB_VERSION}..."
+echo "Cloning gitlab-${GITLAB_EDITION} v.${GITLAB_VERSION}..."
 exec_as_git git clone -q -b v${GITLAB_VERSION} --depth 1 ${GITLAB_CLONE_URL} ${GITLAB_INSTALL_DIR}
 
 GITLAB_SHELL_VERSION=${GITLAB_SHELL_VERSION:-$(cat ${GITLAB_INSTALL_DIR}/GITLAB_SHELL_VERSION)}


### PR DESCRIPTION
This PR adds support for building the enterprise edition as well.  This is controlled via a Docker build argument.  It defaults to building the community edition but you can build the enterprise edition with

```bash
docker build --build-arg GITLAB_EDITION=ee -t sameersbn/gitlab:10.2.2-ee .
```
I kept the documentation changes light as I figured you might want to tweak them a bit.