### PR TITLE
Accelerate map_uidgid

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1144,7 +1144,7 @@ map_uidgid() {
     echo "Mapping UID and GID for ${GITLAB_USER}:${GITLAB_USER} to $USERMAP_UID:$USERMAP_GID"
     groupmod -o -g ${USERMAP_GID} ${GITLAB_USER}
     sed -i -e "s|:${USERMAP_ORIG_UID}:${USERMAP_GID}:|:${USERMAP_UID}:${USERMAP_GID}:|" /etc/passwd
-    find ${GITLAB_HOME} -path ${GITLAB_DATA_DIR}/\* -prune -o -print0 | xargs -0 chown -h ${GITLAB_USER}:
+    find ${GITLAB_HOME} -path ${GITLAB_DATA_DIR}/\* \( ! -uid ${USERMAP_ORIG_UID} -o ! -gid ${USERMAP_ORIG_GID} \) -print0 | xargs -0 chown -h ${GITLAB_USER}: ${GITLAB_HOME}
   fi
 }
 


### PR DESCRIPTION
Hi,

I use the function "map_uidgid" and each restart of the container is at least 30 seconds for the command chown.
With this change I am 1 second.

I added the path ${GITLAB_HOME} at the end to not get an error if the "find" finds nothing.

does this change suit you?