### PR TITLE
Improve docker-compose setup for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 
 services:
   redis:
@@ -7,13 +7,13 @@ services:
     command:
     - --loglevel warning
     volumes:
-    - /srv/docker/gitlab/redis:/var/lib/redis:Z
+    - /srv/docker/gitlab/redis/:/var/lib/redis:Z
 
   postgresql:
     restart: always
     image: sameersbn/postgresql:9.6-2
     volumes:
-    - /srv/docker/gitlab/postgresql:/var/lib/postgresql:Z
+    - /srv/docker/gitlab/postgresql/:/var/lib/postgresql:Z
     environment:
     - DB_USER=gitlab
     - DB_PASS=password
@@ -23,6 +23,9 @@ services:
   gitlab:
     restart: always
     image: sameersbn/gitlab:10.3.2
+    build:
+      context: ./
+      cache_from: ["sameersbn/gitlab:10.3.2"]
     depends_on:
     - redis
     - postgresql
@@ -31,6 +34,7 @@ services:
     - "10022:22"
     volumes:
     - /srv/docker/gitlab/gitlab:/home/git/data:Z
+    - ./assets/runtime/:/etc/docker-gitlab/runtime:Z
     environment:
     - DEBUG=false
 
@@ -148,3 +152,13 @@ services:
     - OAUTH_AZURE_API_KEY=
     - OAUTH_AZURE_API_SECRET=
     - OAUTH_AZURE_TENANT_ID=
+
+    - AWS_BACKUPS=false
+    - AWS_BACKUP_MULTIPART_CHUNK_SIZE=5000
+    - AWS_BACKUP_ENCRYPTION=false
+    - AWS_BACKUP_REGION=foo
+    - AWS_BACKUP_ENDPOINT=foo
+    - AWS_BACKUP_ACCESS_KEY_ID=ffff
+    - AWS_BACKUP_SECRET_ACCESS_KEY=ffff
+    - AWS_BACKUP_BUCKET=fdf
+    - AWS_BACKUP_STORAGE_CLASS=STANDARD_IA

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -1,0 +1,25 @@
+# Running Locally
+
+In order to develop on this you need the following.
+
+Create data folders (or edit the docker-compose file)
+
+    sudo mkdir -p /srv/docker/gitlab/{gitlab,redis,postgresql}
+    sudo chown -R $(whoami) /srv/docker
+
+Docker compose setup
+
+    docker pull sameersbn/gitlab
+    # This will reuse the cache from the pre-built image
+    docker-compose up 
+
+The docker-compose setup will also mount `./assets/runtime/` to `/etc/docker-gitlab/runtime` so it makes it easier to develop/make changes.
+
+Editing any of the `./assets/runtime/` configs can be tested by simply restarting the container instead of rebuilding
+
+    docker-compose restart gitlab
+
+NOTEs.
+
+* docker-compose will not automatically reload `docker-compose.yaml` configuration changes on restart you will have to take down the stack and restart it
+* 


### PR DESCRIPTION
* Bump compose version to 2.2 to leverage cache_from
* Mount runtime assets as volume to allow easier editing
* Add basic how to

I thought I would document my experience working on this project so that others might have an easier time. I found it pretty hard to get started/debug things.