### PR TITLE
[WIP] Replace backup settings configuration to ERB syntax.

### DIFF
--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -502,30 +502,32 @@ production: &base
     pg_schema: {{GITLAB_BACKUP_PG_SCHEMA}}     # default: nil, it means that all schemas will be backed up
     upload:
       # Fog storage connection settings, see http://fog.io/storage/ .
-      #start-aws
+      <% if ENV['AWS_BACKUPS'] %>
       connection:
         provider: AWS
-        region: {{AWS_BACKUP_REGION}}
-        endpoint: {{AWS_BACKUP_ENDPOINT}}
-        path_style: {{AWS_BACKUP_PATH_STYLE}}
-        aws_access_key_id: {{AWS_BACKUP_ACCESS_KEY_ID}}
-        aws_secret_access_key: '{{AWS_BACKUP_SECRET_ACCESS_KEY}}'
+        region: <%= ENV['AWS_BACKUP_REGION'] %>
+        endpoint: <%= ENV['AWS_BACKUP_ENDPOINT'] %>
+        path_style: <%= ENV['AWS_BACKUP_PATH_STYLE'] %>
+        aws_access_key_id: <%= ENV['AWS_BACKUP_ACCESS_KEY_ID'] %>
+        aws_secret_access_key: '<%= ENV['AWS_BACKUP_SECRET_ACCESS_KEY']%>' 
       # The remote 'directory' to store your backups. For S3, this would be the bucket name.
-      remote_directory: '{{AWS_BACKUP_BUCKET}}'
-    #   # Use multipart uploads when file size reaches 100MB, see
-    #   #  http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html
-    #   multipart_chunk_size: 104857600
-    #   # Turns on AWS Server-Side Encryption with Amazon S3-Managed Keys for backups, this is optional
-    #   # encryption: 'AES256'
+      remote_directory: <%= ENV['AWS_BACKUP_BUCKET'] %>'
+      # Use multipart uploads when file size reaches 100MB, see
+      #  http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html
+      multipart_chunk_size: <%= ENV['AWS_BACKUP_MULTIPART_CHUNK_SIZE'] %>
+      <% if ENV['AWS_BACKUP_ENCRYPTION'] %>
+      # Turns on AWS Server-Side Encryption with Amazon S3-Managed Keys for backups, this is optional
+      encryption: 'AES256'
+      <% end %>
       # Fog storage connection settings, see http://fog.io/storage/ .
-      #end-aws
-      #start-gcs
+      <% end %>
+      <% if ENV['GCS_BACKUPS'] %>
       connection:
         provider: Google
         google_storage_access_key_id: {{GCS_BACKUP_ACCESS_KEY_ID}}
         google_storage_secret_access_key: '{{GCS_BACKUP_SECRET_ACCESS_KEY}}'
       remote_directory: '{{GCS_BACKUP_BUCKET}}'
-      #end-gcs
+      <% end %>
 
   ## GitLab Shell settings
   gitlab_shell:

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -782,9 +782,6 @@ gitlab_configure_backups_schedule() {
 
 gitlab_configure_backups_aws() {
     echo "Configuring gitlab::backups::aws..."
-    exec_as_git sed -i "/#start-gcs/,/#end-gcs/d" ${GITLAB_CONFIG}
-    exec_as_git sed -i "/#start-aws/d" ${GITLAB_CONFIG}
-    exec_as_git sed -i "/#end-aws/d" ${GITLAB_CONFIG}
 
     if [[ -z ${AWS_BACKUP_REGION} && -z ${AWS_BACKUP_ENDPOINT} ]]; then
       echo "\nMissing AWS region or endpoint. Aborting...\n"
@@ -799,30 +796,14 @@ gitlab_configure_backups_aws() {
       echo "\nMissing AWS options. Aborting...\n"
       return 1
     fi
-
-    update_template ${GITLAB_CONFIG} \
-      AWS_BACKUP_REGION \
-      AWS_BACKUP_ENDPOINT \
-      AWS_BACKUP_PATH_STYLE \
-      AWS_BACKUP_ACCESS_KEY_ID \
-      AWS_BACKUP_SECRET_ACCESS_KEY \
-      AWS_BACKUP_BUCKET \
-      AWS_BACKUP_MULTIPART_CHUNK_SIZE
 }
 
 gitlab_configure_backup_gcs() {
     echo "Configuring gitlab::backups::gcs..."
-    exec_as_git sed -i "/#start-aws/,/#end-aws/d" ${GITLAB_CONFIG}
-    exec_as_git sed -i "/#start-gcs/d" ${GITLAB_CONFIG}
-    exec_as_git sed -i "/#end-gcs/d" ${GITLAB_CONFIG}
     if [[ -z ${GCS_BACKUP_ACCESS_KEY_ID} || -z ${GCS_BACKUP_SECRET_ACCESS_KEY} || -z ${GCS_BACKUP_BUCKET} ]]; then
       printf "\nMissing GCS options. Aborting...\n"
       return 1
     fi
-    update_template ${GITLAB_CONFIG} \
-      GCS_BACKUP_ACCESS_KEY_ID \
-      GCS_BACKUP_SECRET_ACCESS_KEY \
-      GCS_BACKUP_BUCKET
 }
 
 gitlab_configure_backups() {


### PR DESCRIPTION
This is a prototype to check if this is something you would be willing to experiment with? 

Gitlab uses settingsLogic that support ERB syntax in config files, as well as all rails configuration files such as `database.yaml`

See
https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/initializers/1_settings.rb#L5
https://github.com/settingslogic/settingslogic

> Settingslogic is a simple configuration / settings solution that uses an ERB enabled YAML file. It has been great for our apps, maybe you will enjoy it too. Settingslogic works with Rails, Sinatra, or any Ruby project.

This can be tested by simply booting up gitlab and testing nothing changes, also by starting the rails console and dumping the settings object. 

     bundle exec rails console production
     Settings.backup 

I know this diverges slightly from the standard `sameersbn/` images but gitlab's configuration files and manual sed hacks to get a proper templating language

Let me know if this is something worth exploring and I would be happy to work on converting it.

This would allow us to enable more complex configuration such as Redis Authentication, it simplifies the AWS/Google backup sections.