### PR TITLE
Add GITLAB_PORT into nginx templates

### DIFF
--- a/assets/runtime/config/nginx/gitlab
+++ b/assets/runtime/config/nginx/gitlab
@@ -31,8 +31,8 @@ server {
   ## or delete the /etc/nginx/sites-enabled/default file. This will cause gitlab
   ## to be served if you visit any address that your server responds to, eg.
   ## the ip address of the server (http://x.x.x.x/)n 0.0.0.0:80 default_server;
-  listen 0.0.0.0:80 default_server;
-  listen [::]:80 default_server;
+  listen 0.0.0.0:{{GITLAB_PORT}} default_server;
+  listen [::]:{{GITLAB_PORT}} default_server;
   server_name {{GITLAB_HOST}}; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
 

--- a/assets/runtime/config/nginx/gitlab-pages
+++ b/assets/runtime/config/nginx/gitlab-pages
@@ -2,8 +2,8 @@
 ##
 ## Pages serving host
 server {
-  listen 0.0.0.0:80;
-  listen [::]:80;
+  listen 0.0.0.0:{{GITLAB_PORT}};
+  listen [::]:{{GITLAB_PORT}};
   ## Replace this with something like pages.gitlab.com
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};
   ## Individual nginx logs for GitLab pages

--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -7,8 +7,8 @@ server {
   ## or delete the /etc/nginx/sites-enabled/default file. This will cause gitlab
   ## to be served if you visit any address that your server responds to, eg.
   ## the ip address of the server (http://x.x.x.x/)
-  listen 0.0.0.0:80;
-  listen [::]:80;
+  listen 0.0.0.0:{{GITLAB_PORT}};
+  listen [::]:{{GITLAB_PORT}};
 
   ## Replace this with something like pages.gitlab.com
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};

--- a/assets/runtime/config/nginx/gitlab-registry
+++ b/assets/runtime/config/nginx/gitlab-registry
@@ -7,7 +7,7 @@
 
 ## Redirects all HTTP traffic to the HTTPS host
 server {
-  listen *:80;
+  listen *:{{GITLAB_PORT}};
   server_name  {{GITLAB_REGISTRY_HOST}};
   server_tokens off; ## Don't show the nginx version number, a security best practice
   return 301 https://$http_host:$request_uri;

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -35,8 +35,8 @@ server {
   ## or delete the /etc/nginx/sites-enabled/default file. This will cause gitlab
   ## to be served if you visit any address that your server responds to, eg.
   ## the ip address of the server (http://x.x.x.x/)
-  listen 0.0.0.0:80;
-  listen [::]:80 ipv6only=on default_server;
+  listen 0.0.0.0:{{GITLAB_PORT}};
+  listen [::]:{{GITLAB_PORT}} ipv6only=on default_server;
   server_name _; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
   return 301 https://$host:{{GITLAB_PORT}}$request_uri;

--- a/assets/runtime/config/nginx/gitlab_ci
+++ b/assets/runtime/config/nginx/gitlab_ci
@@ -1,6 +1,6 @@
 # GITLAB CI
 server {
-  listen 80;                        # e.g., listen 192.168.1.1:80;
+  listen {{GITLAB_PORT}};                        # e.g., listen 192.168.1.1:80;
   server_name {{GITLAB_CI_HOST}};   # e.g., server_name source.example.com;
 
   access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_ci_access.log;


### PR DESCRIPTION
This fixes an issue when GITLAB_PORT value are ignored and Ngnix keeps listen on http port 80. This is address https://github.com/sameersbn/docker-gitlab/issues/1427