### PR TITLE
Remove rsa1 ssh_host_key

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1338,7 +1338,6 @@ generate_ssh_host_keys() {
   sed -i "s|HostKey /etc/ssh/|HostKey ${GITLAB_DATA_DIR}/ssh/|g" /etc/ssh/sshd_config
   if [[ ! -e ${GITLAB_DATA_DIR}/ssh/ssh_host_rsa_key ]]; then
     echo -n "Generating OpenSSH host keys... "
-    generate_ssh_key rsa1     ${GITLAB_DATA_DIR}/ssh/ssh_host_key
     generate_ssh_key rsa      ${GITLAB_DATA_DIR}/ssh/ssh_host_rsa_key
     generate_ssh_key dsa      ${GITLAB_DATA_DIR}/ssh/ssh_host_dsa_key
     generate_ssh_key ecdsa    ${GITLAB_DATA_DIR}/ssh/ssh_host_ecdsa_key


### PR DESCRIPTION
This means that the SSH 1 protocol wouldn’t be supported anymore.

Closes #1496 

Signed-off-by: solidnerd <niclas@mietz.io>