### PR TITLE
Update gitlab-rc.yml

### DIFF
--- a/kubernetes/gitlab-rc.yml
+++ b/kubernetes/gitlab-rc.yml
@@ -99,6 +99,9 @@ spec:
           value: "true"
         - name: IMAP_STARTTLS
           value: "false"
+          
+        - name: GITLAB_UPLOADS_STORAGE_PATH
+          value: /home/git/data/shared/public
         ports:
         - name: http
           containerPort: 80


### PR DESCRIPTION
If we use the default uploads dir path, it resides within the images location which is not great.

I guess an easy fix would be to supply the `GITLAB_UPLOADS_STORAGE_PATH`variable to point to the dir which is mounted to a persistent type of storage.