### PR TITLE
Fix uploads object storage aws endpoint variable

### DIFF
--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -201,7 +201,7 @@ production: &base
         aws_secret_access_key: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY}}
         region: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_REGION}}
         host: '{{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_HOST}}' # default: s3.amazonaws.com
-        endpoint: '{{GITLAB_UPLOADS_ENDPOINT_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}' # default: nil
+        endpoint: '{{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}' # default: nil
         path_style: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE}} # Use 'host/bucket_name/object' instead of 'bucket_name.host/object'
 
 


### PR DESCRIPTION
Fixing mistyped variable.

Causing uploads to object storage to fail:

```
2018-05-15T14:30:08.567Z 708 TID-10e474 ObjectStorage::MigrateUploadsWorker JID-6098de53124b6156c0432d86 INFO: start
2018-05-15T14:30:08.591Z 708 TID-10e474 ObjectStorage::MigrateUploadsWorker JID-6098de53124b6156c0432d86 INFO: fail: 0.024 sec
2018-05-15T14:30:08.591Z 708 TID-10e474 WARN: {"context":"Job raised exception","job":{"class":"ObjectStorage::MigrateUploadsWorker","args":[[2],"User","avatar",2],"retry":3,"queue":"object_storage:object_storage_migrate_uploads","queue_namespace":"object_storage","jid":"6098de53124b6156c0432d86","created_at":1526394563.5248544,"enqueued_at":1526394608.566843,"error_message":"bad URI(is not URI?): {{GITLAB_UPLOADS_ENDPOINT_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}","error_class":"ObjectStorage::MigrateUploadsWorker::Report::MigrationFailures","failed_at":1526394563.9735534,"retry_count":0},"jobstr":"{\"class\":\"ObjectStorage::MigrateUploadsWorker\",\"args\":[[2],\"User\",\"avatar\",2],\"retry\":3,\"queue\":\"object_storage:object_storage_migrate_uploads\",\"queue_namespace\":\"object_storage\",\"jid\":\"6098de53124b6156c0432d86\",\"created_at\":1526394563.5248544,\"enqueued_at\":1526394608.566843,\"error_message\":\"bad URI(is not URI?): {{GITLAB_UPLOADS_ENDPOINT_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}\",\"error_class\":\"ObjectStorage::MigrateUploadsWorker::Report::MigrationFailures\",\"failed_at\":1526394563.9735534,\"retry_count\":0}"}
2018-05-15T14:30:08.591Z 708 TID-10e474 WARN: ObjectStorage::MigrateUploadsWorker::Report::MigrationFailures: bad URI(is not URI?): {{GITLAB_UPLOADS_ENDPOINT_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}
2018-05-15T14:30:08.592Z 708 TID-10e474 WARN: /home/git/gitlab/app/workers/object_storage/migrate_uploads_worker.rb:127:in `report!'
```