### PR TITLE
Correct entrypoint.sh causing bootloop in some cases

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ case ${1} in
         SUPERVISOR_PID=$!
         migrate_database
         kill -15 $SUPERVISOR_PID
-        ps h -p $SUPERVISOR_PID && wait $SUPERVISOR_PID
+        ps h -p $SUPERVISOR_PID > /dev/null && wait $SUPERVISOR_PID
         rm -rf /var/run/supervisor.sock
         exec /usr/bin/supervisord -nc /etc/supervisor/supervisord.conf
         ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ case ${1} in
         SUPERVISOR_PID=$!
         migrate_database
         kill -15 $SUPERVISOR_PID
-        wait $SUPERVISOR_PID
+        ps h -p $SUPERVISOR_PID && wait $SUPERVISOR_PID
         rm -rf /var/run/supervisor.sock
         exec /usr/bin/supervisord -nc /etc/supervisor/supervisord.conf
         ;;


### PR DESCRIPTION
Following issue #1626 

Entrypoint executes following commands:
* kill -15 $SUPERVISOR_PID
* wait $SUPERVISOR_PID

This may fail if process is killed sufficiently fast: indeed process may already be killed when wait is invoked, and then results into an error. Command `ps -p` ensures process is still here before waiting to its state to change.