### PR TITLE
Fix for LFS Large File upload

### DIFF
--- a/assets/runtime/config/nginx/gitlab
+++ b/assets/runtime/config/nginx/gitlab
@@ -72,7 +72,7 @@ server {
     proxy_set_header    Upgrade             $http_upgrade;
     proxy_set_header    Connection          $connection_upgrade_gitlab;
 
-	proxy_request_buffering off;
+    proxy_request_buffering off;
 
     proxy_pass http://gitlab-workhorse;
   }

--- a/assets/runtime/config/nginx/gitlab
+++ b/assets/runtime/config/nginx/gitlab
@@ -72,6 +72,8 @@ server {
     proxy_set_header    Upgrade             $http_upgrade;
     proxy_set_header    Connection          $connection_upgrade_gitlab;
 
+	proxy_request_buffering off;
+
     proxy_pass http://gitlab-workhorse;
   }
 

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -119,6 +119,8 @@ server {
     proxy_set_header    Upgrade             $http_upgrade;
     proxy_set_header    Connection          $connection_upgrade_gitlab_ssl;
     
+	proxy_request_buffering off;
+
     proxy_pass http://gitlab-workhorse;
   }
 

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -119,7 +119,7 @@ server {
     proxy_set_header    Upgrade             $http_upgrade;
     proxy_set_header    Connection          $connection_upgrade_gitlab_ssl;
     
-	proxy_request_buffering off;
+    proxy_request_buffering off;
 
     proxy_pass http://gitlab-workhorse;
   }


### PR DESCRIPTION
This tells nginx to not buffer proxied requests. This is required to avoid "io errors" on large LFS transfers.