### PR TITLE
Fix for Redis config to disable protected mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: sameersbn/redis:latest
     command:
     - --loglevel warning
+    - --protected-mode no
     volumes:
     - /srv/docker/gitlab/redis:/var/lib/redis:Z
 


### PR DESCRIPTION
Current config does not work. Process "sidekiq" keeps failing.
Proposed fix:
Config option "protected-mode no" added to docker-compose.yml.
