### PR TITLE
Ed25519 GPG key import fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E1DD270288B4E60
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor logrotate locales curl \
       nginx openssh-server mysql-client postgresql-client redis-tools \
-      git-core ruby${RUBY_VERSION} python2.7 python-docutils nodejs yarn gettext-base \
+      git-core gnupg2 ruby${RUBY_VERSION} python2.7 python-docutils nodejs yarn gettext-base \
       libmysqlclient20 libpq5 zlib1g libyaml-0-2 libssl1.0.0 \
       libgdbm3 libreadline6 libncurses5 libffi6 \
       libxml2 libxslt1.1 libcurl3 libicu55 \


### PR DESCRIPTION
This issue was raised in this thread: https://gitlab.com/gitlab-org/gitlab-ce/issues/36845,
but only ever fixed in omnibus-gitlab. I was able to reproduce this issue with the v11.0.1
release of docker-gitlab. The fix was to add gnupg2 as runtime dep, and now Ed25519 GPG
keys import fine.

Signed-off-by: Tyler Baker <forcedinductionz@gmail.com>