### PR TITLE
clean up the $HOME/.cache directory after installation

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -386,3 +386,6 @@ EOF
 # purge build dependencies and cleanup apt
 DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${BUILD_DEPENDENCIES}
 rm -rf /var/lib/apt/lists/*
+
+# clean up caches
+exec_as_git rm -rf ${GITLAB_HOME}/.cache


### PR DESCRIPTION
Yarn stores every package in a global cache in your user directory on
the file system. This ends up to be around ~400M of extra utilized by
the image and has no benefits whatsoever.

Additionally `go` populates a build cache with will also be cleared
when the ~/.cache directory is purged

/cc @solidnerd