### PR TITLE
Added unzip to Dockerfile. It's needed for pages:deploy task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
       git-core gnupg2 ruby${RUBY_VERSION} python2.7 python-docutils nodejs yarn gettext-base \
       libmysqlclient20 libpq5 zlib1g libyaml-0-2 libssl1.0.0 \
       libgdbm3 libreadline6 libncurses5 libffi6 \
-      libxml2 libxslt1.1 libcurl3 libicu55 libre2-dev tzdata \
+      libxml2 libxslt1.1 libcurl3 libicu55 libre2-dev tzdata unzip \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && locale-gen en_US.UTF-8 \
  && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales \


### PR DESCRIPTION
After upgrading to latest version my GL pages builds started to fail. Symptoms were same as in #1351. According to strace, unzip was really missing:

```
[pid  7212] stat("/home/git/gitlab/vendor/bundle/ruby/2.4.0/bin/unzip",  <unfinished ...>
[pid 21814] futex(0x20ee054, FUTEX_WAIT_PRIVATE, 43697, NULL <unfinished ...>
[pid  7212] <... stat resumed> 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/usr/local/sbin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/usr/local/bin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/usr/sbin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/usr/bin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/sbin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] stat("/bin/unzip", 0x7fc02c1ede00) = -1 ENOENT
[pid  7212] pipe2([44, 48], O_CLOEXEC)  = 0
[pid  7212] rt_sigprocmask(SIG_SETMASK, ~[RTMIN RT_1], [], 8) = 0
```