### PR TITLE
Fix backup config stripping for when AWS & GCS backups are disabled

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -859,7 +859,7 @@ gitlab_configure_backups() {
     GITLAB_BACKUP_ARCHIVE_PERMISSIONS
   gitlab_configure_backups_schedule
   if [[ ${AWS_BACKUPS} != true && ${GCS_BACKUPS} != true ]]; then
-    exec_as_git sed -i "/upload:/,/#end-gcs/d" ${GITLAB_CONFIG}
+    exec_as_git sed -i "/\s\+upload:/,/#end-gcs/d" ${GITLAB_CONFIG}
     return 0
   fi
   if [[ ${AWS_BACKUPS} == true && ${GCS_BACKUPS} == true ]]; then


### PR DESCRIPTION
The `sed` command that has been changed in this PR was too tolerant and found a section in the configuration template that is irrelevant to the backup configuration, specifically [this line](https://github.com/sameersbn/docker-gitlab/blob/91e05e4489a5e62602b7229dabeef73e5cf9ff4d/assets/runtime/config/gitlabhq/gitlab.yml#L161). Consequently it deleted [a large portion of the configuration down to the relevant end marker](https://github.com/sameersbn/docker-gitlab/blob/91e05e4489a5e62602b7229dabeef73e5cf9ff4d/assets/runtime/config/gitlabhq/gitlab.yml#L161-L606) that was required to configure other GitLab features such as object storage, LFS, OmniAuth, etc.

This change causes sed to find [the correct line](https://github.com/sameersbn/docker-gitlab/blob/91e05e4489a5e62602b7229dabeef73e5cf9ff4d/assets/runtime/config/gitlabhq/gitlab.yml#L575) now by telling it to match with leading whitespaces.

It may be a good idea to list issues in this issue tracker that are affected by this here for reference.

*Potentially* related issues:

- #1594 (I tried a similar setup and it didn't work due to this issue)
- #1568 (`GITLAB_GRAVATAR_ENABLED` is affected here if backups are disabled)


<details>
<summary>Changes as they were made by the faulty <code>sed</code> command</summary>

```patch
--- gitlab.yml	2018-09-19 09:27:41.094178212 +0200
+++ gitlab.yml	2018-09-19 09:28:33.697580538 +0200
@@ -158,452 +158,6 @@
     object_store:
       enabled: {{GITLAB_ARTIFACTS_OBJECT_STORE_ENABLED}}
       remote_directory: {{GITLAB_ARTIFACTS_OBJECT_STORE_REMOTE_DIRECTORY}} # The bucket name
-      background_upload: {{GITLAB_ARTIFACTS_OBJECT_STORE_BACKGROUND_UPLOAD}} # Temporary option to limit automatic upload (Default: true)
-      proxy_download: {{GITLAB_ARTIFACTS_OBJECT_STORE_PROXY_DOWNLOAD}} # Passthrough all downloads via GitLab instead of using Redirects to Object Storage
-      connection:
-        provider: {{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_PROVIDER}} # Only AWS supported at the moment
-        aws_access_key_id: {{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID}}
-        aws_secret_access_key: {{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY}}
-        region: {{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_REGION}}
-        host: '{{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_HOST}}' # default: s3.amazonaws.com
-        endpoint: '{{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}' # default: nil
-        path_style: {{GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE}} # Use 'host/bucket_name/object' instead of 'bucket_name.host/object'
-
-
-  ## Git LFS
-  lfs:
-    enabled: {{GITLAB_LFS_ENABLED}}
-    # The location where LFS objects are stored (default: shared/lfs-objects).
-    storage_path: {{GITLAB_LFS_OBJECTS_DIR}}
-    object_store:
-      enabled: {{GITLAB_LFS_OBJECT_STORE_ENABLED}}
-      remote_directory: {{GITLAB_LFS_OBJECT_STORE_REMOTE_DIRECTORY}} # The bucket name
-      direct_upload: {{GITLAB_LFS_OBJECT_STORE_DIRECT_UPLOAD}} # Use Object Storage directly for uploads instead of background uploads if enabled (Default: false)
-      background_upload: {{GITLAB_LFS_OBJECT_STORE_BACKGROUND_UPLOAD}} # Temporary option to limit automatic upload (Default: true)
-      proxy_download: {{GITLAB_LFS_OBJECT_STORE_PROXY_DOWNLOAD}} # Passthrough all downloads via GitLab instead of using Redirects to Object Storage
-      connection:
-        provider: {{GITLAB_LFS_OBJECT_STORE_CONNECTION_PROVIDER}} # Only AWS supported at the moment
-        aws_access_key_id: {{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID}}
-        aws_secret_access_key: {{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY}}
-        region: {{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_REGION}}
-        host: '{{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_HOST}}' # default: s3.amazonaws.com
-        endpoint: '{{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}' # default: nil
-        path_style: {{GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE}} # Use 'host/bucket_name/object' instead of 'bucket_name.host/object'
-
-
-  ## Uploads (attachments, avatars, etc...)
-  uploads:
-    # The location where uploads objects are stored (default: public/).
-    storage_path: {{GITLAB_UPLOADS_STORAGE_PATH}}
-    base_dir: {{GITLAB_UPLOADS_BASE_DIR}}
-    object_store:
-      enabled: {{GITLAB_UPLOADS_OBJECT_STORE_ENABLED}}
-      remote_directory: {{GITLAB_UPLOADS_OBJECT_STORE_REMOTE_DIRECTORY}} # The bucket name
-      direct_upload: {{GITLAB_UPLOADS_OBJECT_STORE_DIRECT_UPLOAD}} # Use Object Storage directly for uploads instead of background uploads if enabled (Default: false)
-      background_upload: {{GITLAB_UPLOADS_OBJECT_STORE_BACKGROUND_UPLOAD}} # Temporary option to limit automatic upload (Default: true)
-      proxy_download: {{GITLAB_UPLOADS_OBJECT_STORE_PROXY_DOWNLOAD}} # Passthrough all downloads via GitLab instead of using Redirects to Object Storage
-      connection:
-        provider: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_PROVIDER}} # Only AWS supported at the moment
-        aws_access_key_id: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID}}
-        aws_secret_access_key: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY}}
-        region: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_REGION}}
-        host: '{{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_HOST}}' # default: s3.amazonaws.com
-        endpoint: '{{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT}}' # default: nil
-        path_style: {{GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE}} # Use 'host/bucket_name/object' instead of 'bucket_name.host/object'
-
-
-
-  ## GitLab Pages
-  pages:
-    enabled: {{GITLAB_PAGES_ENABLED}}
-    # The location where pages are stored (default: shared/pages).
-    # path: shared/pages
-    # The domain under which the pages are served:
-    # http://group.example.com/project
-    # or project path can be a group page: group.example.com
-    host: {{GITLAB_PAGES_DOMAIN}}
-    port: {{GITLAB_PAGES_PORT}} # Set to 443 if you serve the pages with HTTPS
-    https: {{GITLAB_PAGES_HTTPS}} # Set to true if you serve the pages with HTTPS
-    artifacts_server: {{GITLAB_PAGES_ARTIFACTS_SERVER}}
-    external_http: {{GITLAB_PAGES_EXTERNAL_HTTP}} # If defined, enables custom domain support in GitLab Pages
-    external_https: {{GITLAB_PAGES_EXTERNAL_HTTPS}} # If defined, enables custom domain and certificate support in GitLab Pages
-
-
-  ## Mattermost
-  ## For enabling Add to Mattermost button
-  mattermost:
-    enabled: {{GITLAB_MATTERMOST_ENABLED}}
-    host: '{{GITLAB_MATTERMOST_URL}}'
-
-  ## Gravatar
-  ## If using gravatar.com, there's nothing to change here. For Libravatar
-  ## you'll need to provide the custom URLs. For more information,
-  ## see: https://docs.gitlab.com/ee/customization/libravatar.html
-  gravatar:
-    enabled: {{GITLAB_GRAVATAR_ENABLED}}                 # Use user avatar image from Gravatar.com (default: true)
-    # gravatar urls: possible placeholders: %{hash} %{size} %{email} %{username}
-    plain_url: "{{GITLAB_GRAVATAR_HTTP_URL}}"     # default: https://www.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
-    ssl_url:   "{{GITLAB_GRAVATAR_HTTPS_URL}}"    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=identicon
-
-
-  ## Sidekiq
-  sidekiq:
-    log_format: {{GITLAB_SIDEKIQ_LOG_FORMAT}} # (json is also supported)
-
-  ## Auxiliary jobs
-  # Periodically executed jobs, to self-heal GitLab, do external synchronizations, etc.
-  # Please read here for more information: https://github.com/ondrejbartas/sidekiq-cron#adding-cron-job
-  cron_jobs:
-    # Flag stuck CI jobs as failed
-    stuck_ci_jobs_worker:
-      cron: "0 * * * *"
-    # Execute scheduled triggers
-    pipeline_schedule_worker:
-      cron: "{{GITLAB_PIPELINE_SCHEDULE_WORKER_CRON}}"
-    # Remove expired build artifacts
-    expire_build_artifacts_worker:
-      cron: "50 * * * *"
-    # Periodically run 'git fsck' on all repositories. If started more than
-    # once per hour you will have concurrent 'git fsck' jobs.
-    repository_check_worker:
-      cron: "20 * * * *"
-    # Send admin emails once a week
-    admin_email_worker:
-      cron: "0 0 * * 0"
-    # Remove outdated repository archives
-    repository_archive_cache_worker:
-      cron: "0 * * * *"
-
-    # Verify custom GitLab Pages domains
-    pages_domain_verification_cron_worker:
-      cron: "*/15 * * * *"
-
-  registry:
-    enabled: {{GITLAB_REGISTRY_ENABLED}}
-    host: {{GITLAB_REGISTRY_HOST}}
-    port: {{GITLAB_REGISTRY_PORT}}
-    api_url: {{GITLAB_REGISTRY_API_URL}} # internal address to the registry, will be used by GitLab to directly communicate with API
-    key: {{GITLAB_REGISTRY_KEY_PATH}}
-    path: {{GITLAB_REGISTRY_DIR}}
-    issuer: {{GITLAB_REGISTRY_ISSUER}}
-
-  #
-  # 2. GitLab CI settings
-  # ==========================
-
-  gitlab_ci:
-    # Default project notifications settings:
-    #
-    # Send emails only on broken builds (default: true)
-    all_broken_builds: {{GITLAB_NOTIFY_ON_BROKEN_BUILDS}}
-    #
-    # Add pusher to recipients list (default: false)
-    add_pusher: {{GITLAB_NOTIFY_PUSHER}}
-
-    # The location where build traces are stored (default: builds/). Relative paths are relative to Rails.root
-    builds_path: {{GITLAB_BUILDS_DIR}}
-
-  #
-  # 3. Auth settings
-  # ==========================
-
-  ## LDAP settings
-  # You can inspect a sample of the LDAP users with login access by running:
-  #   bundle exec rake gitlab:ldap:check RAILS_ENV=production
-  ldap:
-    enabled: {{LDAP_ENABLED}}
-    servers:
-      ##########################################################################
-      #
-      # Since GitLab 7.4, LDAP servers get ID's (below the ID is 'main'). GitLab
-      # Enterprise Edition now supports connecting to multiple LDAP servers.
-      #
-      # If you are updating from the old (pre-7.4) syntax, you MUST give your
-      # old server the ID 'main'.
-      #
-      ##########################################################################
-      main: # 'main' is the GitLab 'provider ID' of this LDAP server
-        ## label
-        #
-        # A human-friendly name for your LDAP server. It is OK to change the label later,
-        # for instance if you find out it is too large to fit on the web page.
-        #
-        # Example: 'Paris' or 'Acme, Ltd.'
-        label: '{{LDAP_LABEL}}'
-
-        host: '{{LDAP_HOST}}'
-        port: {{LDAP_PORT}}
-        uid: '{{LDAP_UID}}'
-
-        encryption: '{{LDAP_METHOD}}' # "start_tls" or "simple_tls" or "plain"
-        verify_certificates: {{LDAP_VERIFY_SSL}}
-        ca_file: '{{LDAP_CA_FILE}}'
-        ssl_version: '{{LDAP_SSL_VERSION}}'
-
-        bind_dn: '{{LDAP_BIND_DN}}'
-        password: '{{LDAP_PASS}}'
-
-        # Set a timeout, in seconds, for LDAP queries. This helps avoid blocking
-        # a request if the LDAP server becomes unresponsive.
-        # A value of 0 means there is no timeout.
-        timeout: {{LDAP_TIMEOUT}}
-
-        # This setting specifies if LDAP server is Active Directory LDAP server.
-        # For non AD servers it skips the AD specific queries.
-        # If your LDAP server is not AD, set this to false.
-        active_directory: {{LDAP_ACTIVE_DIRECTORY}}
-
-        # If allow_username_or_email_login is enabled, GitLab will ignore everything
-        # after the first '@' in the LDAP username submitted by the user on login.
-        #
-        # Example:
-        # - the user enters 'jane.doe@example.com' and 'p@ssw0rd' as LDAP credentials;
-        # - GitLab queries the LDAP server with 'jane.doe' and 'p@ssw0rd'.
-        #
-        # If you are using "uid: 'userPrincipalName'" on ActiveDirectory you need to
-        # disable this setting, because the userPrincipalName contains an '@'.
-        allow_username_or_email_login: {{LDAP_ALLOW_USERNAME_OR_EMAIL_LOGIN}}
-
-        # To maintain tight control over the number of active users on your GitLab installation,
-        # enable this setting to keep new users blocked until they have been cleared by the admin
-        # (default: false).
-        block_auto_created_users: {{LDAP_BLOCK_AUTO_CREATED_USERS}}
-
-        # Base where we can search for users
-        #
-        #   Ex. ou=People,dc=gitlab,dc=example
-        #
-        base: '{{LDAP_BASE}}'
-
-        # Filter LDAP users
-        #
-        #   Format: RFC 4515 http://tools.ietf.org/search/rfc4515
-        #   Ex. (employeeType=developer)
-        #
-        #   Note: GitLab does not support omniauth-ldap's custom filter syntax.
-        #
-        user_filter: '{{LDAP_USER_FILTER}}'
-
-        # LDAP attributes that GitLab will use to create an account for the LDAP user.
-        # The specified attribute can either be the attribute name as a string (e.g. 'mail'),
-        # or an array of attribute names to try in order (e.g. ['mail', 'email']).
-        # Note that the user's LDAP login will always be the attribute specified as `uid` above.
-        attributes:
-          # The username will be used in paths for the user's own projects
-          # (like `gitlab.example.com/username/project`) and when mentioning
-          # them in issues, merge request and comments (like `@username`).
-          # If the attribute specified for `username` contains an email address,
-          # the GitLab username will be the part of the email address before the '@'.
-          username: ['uid', 'userid', 'sAMAccountName']
-          email:    ['mail', 'email', 'userPrincipalName']
-
-          # If no full name could be found at the attribute specified for `name`,
-          # the full name is determined using the attributes specified for
-          # `first_name` and `last_name`.
-          name:       'cn'
-          first_name: 'givenName'
-          last_name:  'sn'
-
-          # If lowercase_usernames is enabled, GitLab will lower case the username.
-          lowercase_usernames: {{LDAP_LOWERCASE_USERNAMES}}
-
-      # GitLab EE only: add more LDAP servers
-      # Choose an ID made of a-z and 0-9 . This ID will be stored in the database
-      # so that GitLab can remember which LDAP server a user belongs to.
-      # uswest2:
-      #   label:
-      #   host:
-      #   ....
-
-
-  ## OmniAuth settings
-  omniauth:
-    # Allow login via Twitter, Google, etc. using OmniAuth providers
-    enabled: {{OAUTH_ENABLED}}
-
-    # Uncomment this to automatically sign in with a specific omniauth provider's without
-    # showing GitLab's sign-in page (default: show the GitLab sign-in page)
-    auto_sign_in_with_provider: {{OAUTH_AUTO_SIGN_IN_WITH_PROVIDER}}
-
-    # Sync user's email address from the specified Omniauth provider every time the user logs
-    # in (default: nil). And consequently make this field read-only.
-    # sync_email_from_provider: cas3
-
-    # CAUTION!
-    # This allows users to login without having a user account first. Define the allowed providers
-    # using an array, e.g. ["saml", "twitter"], or as true/false to allow all providers or none.
-    # User accounts will be created automatically when authentication was successful.
-    allow_single_sign_on: [{{OAUTH_ALLOW_SSO}}]
-
-    # Locks down those users until they have been cleared by the admin (default: true).
-    block_auto_created_users: {{OAUTH_BLOCK_AUTO_CREATED_USERS}}
-    # Look up new users in LDAP servers. If a match is found (same uid), automatically
-    # link the omniauth identity with the LDAP account. (default: false)
-    auto_link_ldap_user: {{OAUTH_AUTO_LINK_LDAP_USER}}
-
-    # Allow users with existing accounts to login and auto link their account via SAML
-    # login, without having to do a manual login first and manually add SAML
-    # (default: false)
-    auto_link_saml_user: {{OAUTH_AUTO_LINK_SAML_USER}}
-
-    # Set different Omniauth providers as external so that all users creating accounts
-    # via these providers will not be able to have access to internal projects. You
-    # will need to use the full name of the provider, like `google_oauth2` for Google.
-    # Refer to the examples below for the full names of the supported providers.
-    # (default: [])
-    external_providers: [{{OAUTH_EXTERNAL_PROVIDERS}}]
-
-    ## Auth providers
-    # Uncomment the following lines and fill in the data of the auth provider you want to use
-    # If your favorite auth provider is not listed you can use others:
-    # see https://github.com/gitlabhq/gitlab-public-wiki/wiki/Custom-omniauth-provider-configurations
-    # The 'app_id' and 'app_secret' parameters are always passed as the first two
-    # arguments, followed by optional 'args' which can be either a hash or an array.
-    # Documentation for this is available at http://doc.gitlab.com/ce/integration/omniauth.html
-    providers:
-      # See omniauth-cas3 for more configuration details
-      - { name: 'cas3',
-          label: '{{OAUTH_CAS3_LABEL}}',
-          args: {
-                  url: '{{OAUTH_CAS3_SERVER}}',
-                  disable_ssl_verification: {{OAUTH_CAS3_DISABLE_SSL_VERIFICATION}},
-                  login_url: '{{OAUTH_CAS3_LOGIN_URL}}',
-                  service_validate_url: '{{OAUTH_CAS3_VALIDATE_URL}}',
-                  logout_url: '{{OAUTH_CAS3_LOGOUT_URL}}'} }
-       - { name: 'authentiq',
-          app_id: '{{OAUTH_AUTHENTIQ_CLIENT_ID}}',
-          app_secret: 'OAUTH_AUTHENTIQ_CLIENT_SECRET',
-          args: { scope: {{OAUTH_AUTHENTIQ_SCOPE}}, redirect_uri: '{{OAUTH_AUTHENTIQ_REDIRECT_URI}}' } }
-      - { name: 'github',
-          label: 'GitHub',
-          app_id: '{{OAUTH_GITHUB_API_KEY}}',
-          app_secret: '{{OAUTH_GITHUB_APP_SECRET}}',
-          url: "{{OAUTH_GITHUB_URL}}",
-          verify_ssl: {{OAUTH_GITHUB_VERIFY_SSL}},
-          args: { scope: '{{OAUTH_GITHUB_SCOPE}}' } }
-      - { name: 'bitbucket',
-          app_id: '{{OAUTH_BITBUCKET_API_KEY}}',
-          app_secret: '{{OAUTH_BITBUCKET_APP_SECRET}}' }
-      - { name: 'gitlab',
-          label: 'GitLab.com',
-          app_id: '{{OAUTH_GITLAB_API_KEY}}',
-          app_secret: '{{OAUTH_GITLAB_APP_SECRET}}',
-          args: { scope: '{{OAUTH_GITLAB_SCOPE}}' } }
-      - { name: 'google_oauth2',
-          label: 'Google',
-          app_id: '{{OAUTH_GOOGLE_API_KEY}}',
-          app_secret: '{{OAUTH_GOOGLE_APP_SECRET}}',
-          args: {
-            access_type: 'offline',
-            approval_prompt: '{{OAUTH_GOOGLE_APPROVAL_PROMPT}}',
-            hd: [{{OAUTH_GOOGLE_RESTRICT_DOMAIN}}] } }
-      - { name: 'facebook',
-          app_id: '{{OAUTH_FACEBOOK_API_KEY}}',
-          app_secret: '{{OAUTH_FACEBOOK_APP_SECRET}}' }
-      - { name: 'twitter',
-          app_id: '{{OAUTH_TWITTER_API_KEY}}',
-          app_secret: '{{OAUTH_TWITTER_APP_SECRET}}' }
-      - { name: 'saml',
-          label: '{{OAUTH_SAML_LABEL}}',
-          groups_attribute: '{{OAUTH_SAML_GROUPS_ATTRIBUTE}}',
-          external_groups: [{{OAUTH_SAML_EXTERNAL_GROUPS}}],
-          args: {
-                  assertion_consumer_service_url: '{{OAUTH_SAML_ASSERTION_CONSUMER_SERVICE_URL}}',
-                  idp_cert_fingerprint: '{{OAUTH_SAML_IDP_CERT_FINGERPRINT}}',
-                  idp_sso_target_url: '{{OAUTH_SAML_IDP_SSO_TARGET_URL}}',
-                  issuer: '{{OAUTH_SAML_ISSUER}}',
-                  attribute_statements: {
-                    first_name: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_FIRST_NAME}}'],
-                    last_name: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_LAST_NAME}}'],
-                    name: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_NAME}}'],
-                    email: ['{{OAUTH_SAML_ATTRIBUTE_STATEMENTS_EMAIL}}'] },
-                  name_identifier_format: '{{OAUTH_SAML_NAME_IDENTIFIER_FORMAT}}' } }
-      - { name: 'crowd',
-          args: {
-            crowd_server_url: '{{OAUTH_CROWD_SERVER_URL}}',
-            application_name: '{{OAUTH_CROWD_APP_NAME}}',
-            application_password: '{{OAUTH_CROWD_APP_PASSWORD}}' } }
-      - { name: 'auth0',
-          args: {
-            client_id: '{{OAUTH_AUTH0_CLIENT_ID}}',
-            client_secret: '{{OAUTH_AUTH0_CLIENT_SECRET}}',
-            namespace: '{{OAUTH_AUTH0_DOMAIN}}' } }
-      - { name: 'azure_oauth2',
-          args: {
-            client_id: '{{OAUTH_AZURE_API_KEY}}',
-            client_secret: '{{OAUTH_AZURE_API_SECRET}}',
-            tenant_id: '{{OAUTH_AZURE_TENANT_ID}}' } }
-
-    # SSO maximum session duration in seconds. Defaults to CAS default of 8 hours.
-    # cas3:
-    #   session_duration: 28800
-
-  # Shared file storage settings
-  shared:
-    path: {{GITLAB_SHARED_DIR}}
-
-  # Gitaly settings
-  gitaly:
-    # Path to the directory containing Gitaly client executables.
-    client_path: {{GITALY_CLIENT_PATH}}
-    # Default Gitaly authentication token. Can be overriden per storage. Can
-    # be left blank when Gitaly is running locally on a Unix socket, which
-    # is the normal way to deploy Gitaly.
-    token: {{GITALY_TOKEN}}
-
-  #
-  # 4. Advanced settings
-  # ==========================
-
-  ## Repositories settings
-  repositories:
-    # Paths where repositories can be stored. Give the canonicalized absolute pathname.
-    # IMPORTANT: None of the path components may be symlink, because
-    # gitlab-shell invokes Dir.pwd inside the repository path and that results
-    # real path not the symlink.
-    storages: # You must have at least a `default` storage path.
-      default:
-        path: {{GITLAB_REPOS_DIR}}/
-        gitaly_address: unix:/home/git/gitlab/tmp/sockets/private/gitaly.socket # TCP connections are supported too (e.g. tcp://host:port)
-
-  ## Backup settings
-  backup:
-    path: "{{GITLAB_BACKUP_DIR}}"   # Relative paths are relative to Rails.root (default: tmp/backups/)
-    archive_permissions: {{GITLAB_BACKUP_ARCHIVE_PERMISSIONS}} # Permissions for the resulting backup.tar file (default: 0600)
-    keep_time: {{GITLAB_BACKUP_EXPIRY}}   # default: 0 (forever) (in seconds)
-    pg_schema: {{GITLAB_BACKUP_PG_SCHEMA}}     # default: nil, it means that all schemas will be backed up
-    upload:
-      # Fog storage connection settings, see http://fog.io/storage/ .
-      #start-aws
-      connection:
-        provider: AWS
-        region: {{AWS_BACKUP_REGION}}
-        endpoint: {{AWS_BACKUP_ENDPOINT}}
-        path_style: {{AWS_BACKUP_PATH_STYLE}}
-        aws_access_key_id: {{AWS_BACKUP_ACCESS_KEY_ID}}
-        aws_secret_access_key: '{{AWS_BACKUP_SECRET_ACCESS_KEY}}'
-      # The remote 'directory' to store your backups. For S3, this would be the bucket name.
-      remote_directory: '{{AWS_BACKUP_BUCKET}}'
-      #start-multipart-aws
-      # Use multipart uploads when file size reaches 100MB, see
-      # http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html
-      multipart_chunk_size: {{AWS_BACKUP_MULTIPART_CHUNK_SIZE}}
-      #end-multipart-aws
-      #start-encryption-aws
-      # Turns on AWS Server-Side Encryption with Amazon S3-Managed Keys for backups, this is optional
-      encryption: 'AES256'
-      #end-encryption-aws
-      # Specifies Amazon S3 storage class to use for backups, this is optional
-      storage_class: '{{AWS_BACKUP_STORAGE_CLASS}}'
-      # Fog storage connection settings, see http://fog.io/storage/ .
-      #end-aws
-      #start-gcs
-      connection:
-        provider: Google
-        google_storage_access_key_id: {{GCS_BACKUP_ACCESS_KEY_ID}}
-        google_storage_secret_access_key: '{{GCS_BACKUP_SECRET_ACCESS_KEY}}'
-      remote_directory: '{{GCS_BACKUP_BUCKET}}'
-      #end-gcs
 
   ## GitLab Shell settings
   gitlab_shell:
```

</details>

<details>
<summary>List of affected configuration variables</summary>

- `AWS_BACKUP_ACCESS_KEY_ID` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_BUCKET` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_ENDPOINT` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_MULTIPART_CHUNK_SIZE` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_PATH_STYLE` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_REGION` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_SECRET_ACCESS_KEY` (ineffective with AWS/GCS backups disabled anyways)
- `AWS_BACKUP_STORAGE_CLASS` (ineffective with AWS/GCS backups disabled anyways)
- `GCS_BACKUP_ACCESS_KEY_ID` (ineffective with AWS/GCS backups disabled anyways)
- `GCS_BACKUP_BUCKET` (ineffective with AWS/GCS backups disabled anyways)
- `GCS_BACKUP_SECRET_ACCESS_KEY` (ineffective with AWS/GCS backups disabled anyways)
- `GITALY_CLIENT_PATH`
- `GITALY_TOKEN`
- `GITLAB_ARTIFACTS_OBJECT_STORE_BACKGROUND_UPLOAD`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_HOST`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_REGION`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY`
- `GITLAB_ARTIFACTS_OBJECT_STORE_CONNECTION_PROVIDER`
- `GITLAB_ARTIFACTS_OBJECT_STORE_ENABLED`
- `GITLAB_ARTIFACTS_OBJECT_STORE_PROXY_DOWNLOAD`
- `GITLAB_ARTIFACTS_OBJECT_STORE_REMOTE_DIRECTORY`
- `GITLAB_BACKUP_ARCHIVE_PERMISSIONS`
- `GITLAB_BACKUP_DIR`
- `GITLAB_BACKUP_EXPIRY`
- `GITLAB_BACKUP_PG_SCHEMA`
- `GITLAB_BUILDS_DIR`
- `GITLAB_GRAVATAR_ENABLED`
- `GITLAB_GRAVATAR_HTTPS_URL`
- `GITLAB_GRAVATAR_HTTP_URL`
- `GITLAB_LFS_ENABLED`
- `GITLAB_LFS_OBJECTS_DIR`
- `GITLAB_LFS_OBJECT_STORE_BACKGROUND_UPLOAD`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_HOST`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_REGION`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY`
- `GITLAB_LFS_OBJECT_STORE_CONNECTION_PROVIDER`
- `GITLAB_LFS_OBJECT_STORE_DIRECT_UPLOAD`
- `GITLAB_LFS_OBJECT_STORE_ENABLED`
- `GITLAB_LFS_OBJECT_STORE_PROXY_DOWNLOAD`
- `GITLAB_LFS_OBJECT_STORE_REMOTE_DIRECTORY`
- `GITLAB_MATTERMOST_ENABLED`
- `GITLAB_MATTERMOST_URL`
- `GITLAB_NOTIFY_ON_BROKEN_BUILDS`
- `GITLAB_NOTIFY_PUSHER`
- `GITLAB_PAGES_ARTIFACTS_SERVER`
- `GITLAB_PAGES_DOMAIN`
- `GITLAB_PAGES_ENABLED`
- `GITLAB_PAGES_EXTERNAL_HTTP`
- `GITLAB_PAGES_EXTERNAL_HTTPS`
- `GITLAB_PAGES_HTTPS`
- `GITLAB_PAGES_PORT`
- `GITLAB_PIPELINE_SCHEDULE_WORKER_CRON`
- `GITLAB_REGISTRY_API_URL`
- `GITLAB_REGISTRY_DIR`
- `GITLAB_REGISTRY_ENABLED`
- `GITLAB_REGISTRY_HOST`
- `GITLAB_REGISTRY_ISSUER`
- `GITLAB_REGISTRY_KEY_PATH`
- `GITLAB_REGISTRY_PORT`
- `GITLAB_REPOS_DIR`
- `GITLAB_SHARED_DIR`
- `GITLAB_SIDEKIQ_LOG_FORMAT`
- `GITLAB_UPLOADS_BASE_DIR`
- `GITLAB_UPLOADS_OBJECT_STORE_BACKGROUND_UPLOAD`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_ENDPOINT`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_HOST`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_PATH_STYLE`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_REGION`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_AWS_SECRET_ACCESS_KEY`
- `GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_PROVIDER`
- `GITLAB_UPLOADS_OBJECT_STORE_DIRECT_UPLOAD`
- `GITLAB_UPLOADS_OBJECT_STORE_ENABLED`
- `GITLAB_UPLOADS_OBJECT_STORE_PROXY_DOWNLOAD`
- `GITLAB_UPLOADS_OBJECT_STORE_REMOTE_DIRECTORY`
- `GITLAB_UPLOADS_STORAGE_PATH`
- `LDAP_ACTIVE_DIRECTORY`
- `LDAP_ALLOW_USERNAME_OR_EMAIL_LOGIN`
- `LDAP_BASE`
- `LDAP_BIND_DN`
- `LDAP_BLOCK_AUTO_CREATED_USERS`
- `LDAP_CA_FILE`
- `LDAP_ENABLED`
- `LDAP_HOST`
- `LDAP_LABEL`
- `LDAP_LOWERCASE_USERNAMES`
- `LDAP_METHOD`
- `LDAP_PASS`
- `LDAP_PORT`
- `LDAP_SSL_VERSION`
- `LDAP_TIMEOUT`
- `LDAP_UID`
- `LDAP_USER_FILTER`
- `LDAP_VERIFY_SSL`
- `OAUTH_ALLOW_SSO`
- `OAUTH_AUTH0_CLIENT_ID`
- `OAUTH_AUTH0_CLIENT_SECRET`
- `OAUTH_AUTH0_DOMAIN`
- `OAUTH_AUTHENTIQ_CLIENT_ID`
- `OAUTH_AUTHENTIQ_REDIRECT_URI`
- `OAUTH_AUTHENTIQ_SCOPE`
- `OAUTH_AUTO_LINK_LDAP_USER`
- `OAUTH_AUTO_LINK_SAML_USER`
- `OAUTH_AUTO_SIGN_IN_WITH_PROVIDER`
- `OAUTH_AZURE_API_KEY`
- `OAUTH_AZURE_API_SECRET`
- `OAUTH_AZURE_TENANT_ID`
- `OAUTH_BITBUCKET_API_KEY`
- `OAUTH_BITBUCKET_APP_SECRET`
- `OAUTH_BLOCK_AUTO_CREATED_USERS`
- `OAUTH_CAS3_DISABLE_SSL_VERIFICATION`
- `OAUTH_CAS3_LABEL`
- `OAUTH_CAS3_LOGIN_URL`
- `OAUTH_CAS3_LOGOUT_URL`
- `OAUTH_CAS3_SERVER`
- `OAUTH_CAS3_VALIDATE_URL`
- `OAUTH_CROWD_APP_NAME`
- `OAUTH_CROWD_APP_PASSWORD`
- `OAUTH_CROWD_SERVER_URL`
- `OAUTH_ENABLED`
- `OAUTH_EXTERNAL_PROVIDERS`
- `OAUTH_FACEBOOK_API_KEY`
- `OAUTH_FACEBOOK_APP_SECRET`
- `OAUTH_GITHUB_API_KEY`
- `OAUTH_GITHUB_APP_SECRET`
- `OAUTH_GITHUB_SCOPE`
- `OAUTH_GITHUB_URL`
- `OAUTH_GITHUB_VERIFY_SSL`
- `OAUTH_GITLAB_API_KEY`
- `OAUTH_GITLAB_APP_SECRET`
- `OAUTH_GITLAB_SCOPE`
- `OAUTH_GOOGLE_API_KEY`
- `OAUTH_GOOGLE_APPROVAL_PROMPT`
- `OAUTH_GOOGLE_APP_SECRET`
- `OAUTH_GOOGLE_RESTRICT_DOMAIN`
- `OAUTH_SAML_ASSERTION_CONSUMER_SERVICE_URL`
- `OAUTH_SAML_ATTRIBUTE_STATEMENTS_EMAIL`
- `OAUTH_SAML_ATTRIBUTE_STATEMENTS_FIRST_NAME`
- `OAUTH_SAML_ATTRIBUTE_STATEMENTS_LAST_NAME`
- `OAUTH_SAML_ATTRIBUTE_STATEMENTS_NAME`
- `OAUTH_SAML_EXTERNAL_GROUPS`
- `OAUTH_SAML_GROUPS_ATTRIBUTE`
- `OAUTH_SAML_IDP_CERT_FINGERPRINT`
- `OAUTH_SAML_IDP_SSO_TARGET_URL`
- `OAUTH_SAML_ISSUER`
- `OAUTH_SAML_LABEL`
- `OAUTH_SAML_NAME_IDENTIFIER_FORMAT`
- `OAUTH_TWITTER_API_KEY`
- `OAUTH_TWITTER_APP_SECRET`


</details>

