### PR TITLE
Add support and document how to expose ssh port in dockerized gitlab-ce

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
     - [External Issue Trackers](#external-issue-trackers)
     - [Host UID / GID Mapping](#host-uid--gid-mapping)
     - [Piwik](#piwik)
+    - [Exposing ssh port in dockerized gitlab-ce](docs/exposing-ssh-port.md)
     - [Available Configuration Parameters](#available-configuration-parameters)
 - [Maintenance](#maintenance)
     - [Creating Backups](#creating-backups)
@@ -800,6 +801,7 @@ These options should contain something like:
 
 - `PIWIK_URL=piwik.example.org`
 - `PIWIK_SITE_ID=42`
+
 
 ### Available Configuration Parameters
 

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -210,6 +210,7 @@ sed -i \
   -e "s|^[#]*UsePrivilegeSeparation yes|UsePrivilegeSeparation no|" \
   -e "s|^[#]*PasswordAuthentication yes|PasswordAuthentication no|" \
   -e "s|^[#]*LogLevel INFO|LogLevel VERBOSE|" \
+  -e "s|^[#]*AuthorizedKeysFile.*|AuthorizedKeysFile %h/.ssh/authorized_keys %h/.ssh/authorized_keys_proxy|" \
   /etc/ssh/sshd_config
 echo "UseDNS no" >> /etc/ssh/sshd_config
 

--- a/contrib/expose-gitlab-ssh-port.sh
+++ b/contrib/expose-gitlab-ssh-port.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -ev
+
+GITLAB_USERGROUP=${GITLAB_USERGROUP:-1010}
+GITLAB_SSH_PORT=${GITLAB_SSH_PORT:-9922}
+
+if ! id -u git >> /dev/null 2>&1; then
+  groupadd -g ${GITLAB_USERGROUP} git
+  useradd -m -u ${GITLAB_USERGROUP} -g git -s /bin/sh -d /home/git git
+fi
+su git -c "mkdir -p /home/git/.ssh/"
+
+su git -c "if [ ! -f /home/git/.ssh/id_rsa ]; then ssh-keygen -t rsa -b 4096 -N \"\" -f /home/git/.ssh/id_rsa; fi"
+su git -c "if [ -f /home/git/.ssh/id_rsa.pub ]; then mv /home/git/.ssh/id_rsa.pub /home/git/.ssh/authorized_keys_proxy; fi"
+
+mkdir -p /home/git/gitlab-shell/bin/
+rm -f /home/git/gitlab-shell/bin/gitlab-shell
+tee -a /home/git/gitlab-shell/bin/gitlab-shell > /dev/null <<EOF
+#!/bin/sh
+
+ssh -i /home/git/.ssh/id_rsa -p ${GITLAB_SSH_PORT} -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"\$SSH_ORIGINAL_COMMAND\" \$0 \$@"
+EOF
+chown git:git /home/git/gitlab-shell/bin/gitlab-shell
+chmod u+x /home/git/gitlab-shell/bin/gitlab-shell
+
+mkdir -p /var/lib/gitlab/data/.ssh/
+chown git:git -R /var/lib/gitlab/data/.ssh/
+chown git:git -R /home/git/.ssh
+su git -c "touch /var/lib/gitlab/data/.ssh/authorized_keys"
+rm -f /home/git/.ssh/authorized_keys
+su git -c "ln -s /var/lib/gitlab/data/.ssh/authorized_keys /home/git/.ssh/authorized_keys"
+
+echo "Next start GitLab container"

--- a/docs/exposing-ssh-port.md
+++ b/docs/exposing-ssh-port.md
@@ -1,0 +1,8 @@
+# Exposing ssh port in dockerized gitlab-ce
+
+This is how to expose this internal ssh port without affecting the existing ssh port on the host server:
+
+* use this configuration script: [`../contrib/expose-gitlab-ssh-port.sh`](../contrib/expose-gitlab-ssh-port.sh)
+* see implementation example in Vagrant: [harobed/docker-gitlab-vagrant-test
+](https://github.com/harobed/docker-gitlab-vagrant-test)
+* more information, see [« Exposing ssh port in dockerized gitlab-ce »](https://blog.xiaket.org/2017/exposing.ssh.port.in.dockerized.gitlab-ce.html) post


### PR DESCRIPTION
Hi,

the goal of this Pull Request is to add support and document how to expose ssh port in dockerized gitlab-ce.

To implement that, I needed to add `%h/.ssh/authorized_keys_proxy` to `AuthorizedKeysFile` parameter in `/etc/ssh/sshd_config` to support ssh host forwarding to GitLab container.

How to test it: https://github.com/harobed/docker-gitlab-vagrant-test