### PR TITLE
fix bootloop for rare race condition between kill and wait

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ case ${1} in
         SUPERVISOR_PID=$!
         migrate_database
         kill -15 $SUPERVISOR_PID
-        ps h -p $SUPERVISOR_PID > /dev/null && wait $SUPERVISOR_PID
+        ps h -p $SUPERVISOR_PID > /dev/null && wait $SUPERVISOR_PID || true
         rm -rf /var/run/supervisor.sock
         exec /usr/bin/supervisord -nc /etc/supervisor/supervisord.conf
         ;;


### PR DESCRIPTION
`wait` will throw an error if a process it waits for is terminated by an external signal. Together with `set -e` this will stop the whole entrypoint script. I guess this issues only crops up very rarely, as the `kill` command already waits for the supervisor process to shut down, and the test using `ps h -p $SUPERVISOR_PID` returns false and thus `wait` is never called.

You can check the behavior using following simple script:

```bash
#!/bin/bash
#set -e
echo "Testing wait command"
sleep 20 &
pid=$!
kill $pid
wait $pid
echo $pid was terminated.
```
as long as `set -e` is commented out, `$pid was terminated` will print. If you enable `set -e`, the last line will not be printed, as the script fails in the `wait` command.