### PR TITLE
fix double CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,8 @@ docker:build:branches:
   stage: build
   only:
     - branches
+  except:
+    - master
   script:
     - docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASS} ${CI_REGISTRY}
     - docker build


### PR DESCRIPTION
Exclude master branch from docker:build:branches

@solidnerd Currently when building master is run twice, both the jobs, `docker:build` and `docker:build:branches` are triggerd when building the master.

Provided fixes this.
Think we both missed it.