### PR TITLE
Move labels to lower a layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,6 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=11.5.2
 
-LABEL \
-    maintainer="sameer@damagehead.com" \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.build-date=${BUILD_DATE} \
-    org.label-schema.name=gitlab \
-    org.label-schema.vendor=damagehead \
-    org.label-schema.url="https://github.com/sameersbn/docker-gitlab" \
-    org.label-schema.vcs-url="https://github.com/sameersbn/docker-gitlab.git" \
-    org.label-schema.vcs-ref=${VCS_REF} \
-    com.damagehead.gitlab.license=MIT
-
 ENV GITLAB_VERSION=${VERSION} \
     RUBY_VERSION=2.5 \
     GOLANG_VERSION=1.10.5 \
@@ -71,6 +60,17 @@ RUN bash ${GITLAB_BUILD_DIR}/install.sh
 COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
+
+LABEL \
+    maintainer="sameer@damagehead.com" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.build-date=${BUILD_DATE} \
+    org.label-schema.name=gitlab \
+    org.label-schema.vendor=damagehead \
+    org.label-schema.url="https://github.com/sameersbn/docker-gitlab" \
+    org.label-schema.vcs-url="https://github.com/sameersbn/docker-gitlab.git" \
+    org.label-schema.vcs-ref=${VCS_REF} \
+    com.damagehead.gitlab.license=MIT
 
 EXPOSE 22/tcp 80/tcp 443/tcp
 


### PR DESCRIPTION
This will speed docker build with caches because the label layer will be invalidated a very late stage.