### PR TITLE
fix image builds on docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && locale-gen en_US.UTF-8 \
  && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales \
- && gem install --no-document bundler \
+ && gem install --no-document bundler -v 1.17.3 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY assets/build/ ${GITLAB_BUILD_DIR}/

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -166,7 +166,7 @@ exec_as_git yarn install --production --pure-lockfile
 exec_as_git yarn add ajv@^4.0.0
 
 echo "Compiling assets. Please be patient, this could take a while..."
-exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true
+exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true NODE_OPTIONS="--max-old-space-size=4096"
 
 # remove auto generated ${GITLAB_DATA_DIR}/config/secrets.yml
 rm -rf ${GITLAB_DATA_DIR}/config/secrets.yml


### PR DESCRIPTION
Builds on Docker hub have been failing with the following messages:

```
I, [2019-01-02T16:21:37.618336 #12522] INFO -- : Writing /home/git/gitlab/public/assets/illustrations/welcome/lightbulb-e1011792d93b5dfa8b060db664055b1557eff7eda5cfca9d5df923b908f58818.svg.gz
I, [2019-01-02T16:21:37.620507 #12522] INFO -- : Writing /home/git/gitlab/public/assets/illustrations/wiki_login_empty-708b56f5a87bfddbd8b0581f56632e700578c4edf005cee392f27520f22aa0eb.svg
I, [2019-01-02T16:21:37.621345 #12522] INFO -- : Writing /home/git/gitlab/public/assets/illustrations/wiki_login_empty-708b56f5a87bfddbd8b0581f56632e700578c4edf005cee392f27520f22aa0eb.svg.gz
I, [2019-01-02T16:21:37.623653 #12522] INFO -- : Writing /home/git/gitlab/public/assets/illustrations/wiki_logout_empty-d57f30fe8cc4501a4cb26b47c94c77c741b99f961ea6d1413154cfe3ffa21163.svg
I, [2019-01-02T16:21:37.624455 #12522] INFO -- : Writing /home/git/gitlab/public/assets/illustrations/wiki_logout_empty-d57f30fe8cc4501a4cb26b47c94c77c741b99f961ea6d1413154cfe3ffa21163.svg.gz
/home/git/gitlab/node_modules/.bin/webpack --config /home/git/gitlab/config/webpack.config.js --bail
<--- Last few GCs --->
[13730:0x28860f0] 988266 ms: Mark-sweep 1374.7 (1477.4) -> 1374.5 (1480.4) MB, 3069.1 / 0.0 ms allocation failure GC in old space requested
[13730:0x28860f0] 991361 ms: Mark-sweep 1374.5 (1480.4) -> 1374.4 (1448.4) MB, 3095.1 / 0.0 ms last resort GC in old space requested
[13730:0x28860f0] 994441 ms: Mark-sweep 1374.4 (1448.4) -> 1374.4 (1448.4) MB, 3079.3 / 0.0 ms last resort GC in old space requested
<--- JS stacktrace --->
==== JS stack trace =========================================
Security context: 0x1e5edd8258b9 <JSObject>
0: builtin exit frame: stringify(this=0x1e5edd818371 <Object map = 0x14c1561848d9>,0x344d58b822d1 <undefined>,0x344d58b822d1 <undefined>,0x53984f13a39 <Object map = 0x391ba72bc901>)
1: arguments adaptor frame: 1->3
2: toString [0x344d58b822d1 <undefined>:13814] [bytecode=0x12dcd88f45e1 offset=28](this=0x2a62f56c4709 <Object map = 0xfc6252bba91>)
3: minify [0x344d58b822d1 <undefi...
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
1: node::Abort() [node]
2: 0x8ccf9c [node]
3: v8::Utils::ReportOOMFailure(char const*, bool) [node]
4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
5: v8::internal::Factory::NewRawOneByteString(int, v8::internal::PretenureFlag) [node]
6: v8::internal::String::SlowFlatten(v8::internal::Handle<v8::internal::ConsString>, v8::internal::PretenureFlag) [node]
7: v8::internal::JsonStringifier::SerializeString(v8::internal::Handle<v8::internal::String>) [node]
8: v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<true>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
9: v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<false>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
10: v8::internal::JsonStringifier::Stringify(v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>) [node]
11: v8::internal::Builtin_JsonStringify(int, v8::internal::Object**, v8::internal::Isolate*) [node]
12: 0x14dd4790697d
rake aborted!
Command failed with status (): [/home/git/gitlab/node_modules/.bin/webpack...]
/home/git/gitlab/vendor/bundle/ruby/2.5.0/gems/webpack-rails-0.9.11/lib/tasks/webpack.rake:17:in `block (2 levels) in <top (required)>'
/home/git/gitlab/vendor/bundle/ruby/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => gitlab:assets:compile => webpack:compile
(See full trace by running task with --trace)
The command '/bin/sh -c bash ${GITLAB_BUILD_DIR}/install.sh' returned a non-zero code: 1
build hook failed! (1)
```

https://gitlab.com/gitlab-org/gitlab-ce/issues/45900#current-potential-remedies-temporary indicates that the possible workaround could be the use of `NODE_OPTIONS=--max-old-space-size=4096` 