### PR TITLE
Add support for `receive.advertisePushOptions`

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -62,6 +62,8 @@ EOF
 exec_as_git git config --global core.autocrlf input
 exec_as_git git config --global gc.auto 0
 exec_as_git git config --global repack.writeBitmaps true
+exec_as_git git config --global receive.advertisePushOptions true
+
 
 # shallow clone gitlab-ce
 echo "Cloning gitlab-ce v.${GITLAB_VERSION}..."


### PR DESCRIPTION
See [install](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/install/installation.md)
which suggests doing:

```
sudo -u git -H git config --global receive.advertisePushOptions true
```

Resolves https://github.com/sameersbn/docker-gitlab/issues/1856

Signed-off-by: Don Bowman <db@donbowman.ca>