### PR TITLE
Fix `gitlab:assets:compile` task for relative URL root setups

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1786,7 +1786,7 @@ migrate_database() {
     # assets need to be recompiled when GITLAB_RELATIVE_URL_ROOT is used
     if [[ -n ${GITLAB_RELATIVE_URL_ROOT} ]]; then
       echo "Recompiling assets (relative_url in use), this could take a while..."
-      exec_as_git bundle exec rake gitlab:assets:compile >/dev/null 2>&1
+      exec_as_git bundle exec rake gitlab:assets:compile NODE_OPTIONS="--max-old-space-size=4096" >/dev/null 2>&1
     fi
 
     echo "Clearing cache..."


### PR DESCRIPTION
This makes container startup/upgrades use the same `NODE_OPTIONS` as
the Docker image build process.

Fixes #1896