### PR TITLE
Fix nginx config template gitlab-pages-ssl

### DIFF
--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -23,7 +23,7 @@ server {
 ## Pages serving host
 server {
   listen 0.0.0.0:443 ssl;
-  listen [::]:443 ipv6only=on ssl http2;
+  listen [::]:443 ssl http2;
 
   ## Replace this with something like pages.gitlab.com
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};


### PR DESCRIPTION
ipv6only parameter can only be set once and turned on by default. If you set it >1 time, nginx will fail at startup.

https://nginx.org/en/docs/http/ngx_http_core_module.html#listen

> ipv6only=on|off
this parameter (0.7.42) determines (via the IPV6_V6ONLY socket option) whether an IPv6 socket listening on a wildcard address [::] will accept only IPv6 connections or both IPv6 and IPv4 connections. This parameter is turned on by default. It can only be set once on start.
