### PR TITLE
Fix behaviour of gitlab:backup:restore/backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,14 @@ A backup will be created in the backups folder of the [Data Store](#data-store).
 When using `docker-compose` you may use the following command to execute the backup.
 
 ```bash
+docker-compose rm -sf gitlab
 docker-compose run --rm gitlab app:rake gitlab:backup:create
+```
+
+Afterwards you can bring your Instance back with the following command:
+
+```bash
+docker-compose up -d
 ```
 
 ## Restoring Backups
@@ -1240,6 +1247,7 @@ When using `docker-compose` you may use the following command to execute the res
 docker-compose run --rm gitlab app:rake gitlab:backup:restore # List available backups
 docker-compose run --rm gitlab app:rake gitlab:backup:restore BACKUP=1417624827 # Choose to restore from 1417624827
 ```
+
 
 ## Host Key Backups (ssh)
 

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -402,6 +402,19 @@ stdout_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
 stderr_logfile=${GITLAB_LOG_DIR}/supervisor/%(program_name)s.log
 EOF
 
+
+cat > /etc/supervisor/conf.d/groups.conf <<EOF
+[group:core]
+programs=gitaly
+priority=5
+[group:gitlab]
+programs=unicorn,gitlab-workhorse
+priority=10
+[group:gitlab_extensions]
+programs=sshd,nginx,mail_room,cron
+priority=20
+EOF
+
 # purge build dependencies and cleanup apt
 DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${BUILD_DEPENDENCIES}
 rm -rf /var/lib/apt/lists/*

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1801,7 +1801,16 @@ execute_raketask() {
     return 1
   fi
 
+  if [[ ${1} == gitlab:backup:create  ]]; then
+    /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+    supervisorctl stop gitlab_extensions:*
+    supervisorctl stop gitlab:*
+  fi
+
   if [[ ${1} == gitlab:backup:restore ]]; then
+    /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+    supervisorctl stop gitlab_extensions:*
+    supervisorctl stop gitlab:*
     interactive=true
     for arg in $@
     do


### PR DESCRIPTION
This will bring the old behaviour for backups back.

Since 10.8 GitLab requires Gitaly as core process. Gitaly needs to be
run to make backups successfuly.

For this case we will start all proccess to let handle the backup and
restore correctly like before.

Signed-off-by: solidnerd <niclas@mietz.io>