### PR TITLE
Fixed. `GitLab: Disallowed command` when ssh test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
               --build-arg BUILD_DATE="$(date +"%Y-%m-%d %H:%M:%S%:z")" \
               --build-arg VCS_REF=$(git rev-parse --short HEAD) \
               -t ${IMAGE_NAME}:$(cat VERSION) .
+          no_output_timeout: 30m
 
       - run:
           name: Launching container for testing

--- a/contrib/expose-gitlab-ssh-port.sh
+++ b/contrib/expose-gitlab-ssh-port.sh
@@ -18,7 +18,11 @@ rm -f /home/git/gitlab-shell/bin/gitlab-shell
 tee -a /home/git/gitlab-shell/bin/gitlab-shell > /dev/null <<EOF
 #!/bin/sh
 
-ssh -i /home/git/.ssh/id_rsa -p ${GITLAB_SSH_PORT} -o StrictHostKeyChecking=no git@127.0.0.1 "SSH_ORIGINAL_COMMAND=\"\$SSH_ORIGINAL_COMMAND\" \$0 \$@"
+if [ -n "\${SSH_ORIGINAL_COMMAND}" ]; then
+  ssh_original_command="SSH_ORIGINAL_COMMAND=\"\$SSH_ORIGINAL_COMMAND\""
+fi
+
+ssh -i /home/git/.ssh/id_rsa -p ${GITLAB_SSH_PORT} -o StrictHostKeyChecking=no git@127.0.0.1 "\$ssh_original_command \$0 \$@"
 EOF
 chown git:git /home/git/gitlab-shell/bin/gitlab-shell
 chmod u+x /home/git/gitlab-shell/bin/gitlab-shell


### PR DESCRIPTION
When ssh test command (e.g. `ssh -T git@gitlab.example.com` ) is executed, `$SSH_ORIGINAL_COMMAND` is empty.

If empty `$SSH_ORIGINAL_COMMAND` is passed to gitlab-shell in container, ssh test is failed

# Expected

```bash
$ ssh -T git@gitlab.example.com
Welcome to GitLab, @sue445!
```

# Actual

```bash
$ ssh -T git@gitlab.example.com
> GitLab: Disallowed command
```

So I tried not to pass empty `$SSH_ORIGINAL_COMMAND` into container.