### PR TITLE
Fix Auth0 Scope config parsing

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -615,7 +615,7 @@ gitlab_configure_oauth_auth0() {
       OAUTH_AUTH0_DOMAIN \
       OAUTH_AUTH0_SCOPE
   else
-    exec_as_git sed -i "/name: 'auth0'/,/{{OAUTH_AUTH0_DOMAIN}}/d" ${GITLAB_CONFIG}
+    exec_as_git sed -i "/name: 'auth0'/,/{{OAUTH_AUTH0_SCOPE}}/d" ${GITLAB_CONFIG}
   fi
 }
 


### PR DESCRIPTION
This will fix the default behaviour if AUTH0 scope isn't enabled.

Otherwise the container will crash.