### PR TITLE
Fix GITLAB_PAGES_ACCESS_REDIRECT_URI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ Below is the complete list of available options that can be used to customize yo
 | `GITLAB_PAGES_ACCESS_CONTROL_SERVER` | Gitlab instance URI, example: `https://gitlab.example.io` |
 | `GITLAB_PAGES_ACCESS_CLIENT_ID` | Client ID from earlier generated OAuth application |
 | `GITLAB_PAGES_ACCESS_CLIENT_SECRET` | Client Secret from earlier genereated OAuth application |
-| `GITLAB_PAGES_ACCESS_REDIRECT_URI` | Redirect URI, non existing pages domain to redirect to pages daemon, `https://projects.example.io` |
+| `GITLAB_PAGES_ACCESS_REDIRECT_URI` | Redirect URI, non existing pages domain to redirect to pages daemon, `https://projects.example.io/auth` |
 | `GITLAB_HTTPS` | Set to `true` to enable https support, disabled by default. |
 | `GITALY_CLIENT_PATH` | Set default path for gitaly. defaults to `/home/git/gitaly` |
 | `GITALY_TOKEN` | Set a gitaly token, blank by default. |


### PR DESCRIPTION
This PR fixes documentation of `GITLAB_PAGES_ACCESS_REDIRECT_URI` environment variable. Currently, when GitLab Pages are configured according to the README, accessing GitLab Page results in redirect loop, which is caused by misconfigured redirect URL.