### PR TITLE
Remove deprecated "ssl" directives from nginx

### DIFF
--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -31,7 +31,6 @@ server {
 
   ## Strong SSL Security
   ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
-  ssl on;
   ssl_certificate {{SSL_PAGES_CERT_PATH}};
   ssl_certificate_key {{SSL_PAGES_KEY_PATH}};
 

--- a/assets/runtime/config/nginx/gitlab-registry
+++ b/assets/runtime/config/nginx/gitlab-registry
@@ -27,7 +27,6 @@ server {
 
   ## Strong SSL Security
   ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
-  ssl on;
   ssl_certificate {{SSL_REGISTRY_CERT_PATH}};
   ssl_certificate_key {{SSL_REGISTRY_KEY_PATH}};
 

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -53,7 +53,6 @@ server {
 
   ## Strong SSL Security
   ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
-  ssl on;
   ssl_certificate {{SSL_CERTIFICATE_PATH}};
   ssl_certificate_key {{SSL_KEY_PATH}};
   ssl_verify_client {{SSL_VERIFY_CLIENT}};


### PR DESCRIPTION
Before this commit running "nginx -c -f /etc/nginx/nginx.conf" warned:

    nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/sites-enabled/gitlab:60

## Reproduction

    # docker exec -it gitlab nginx -t -c /etc/nginx/nginx.conf
    nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/sites-enabled/gitlab:60
    nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
    nginx: configuration file /etc/nginx/nginx.conf test is successful

    ## Remove "ssl on;"
    # docker exec -it gitlab sed -i '/ssl on;/d' /etc/nginx/sites-enabled/gitlab

    # docker exec -it gitlab nginx -t -c /etc/nginx/nginx.conf
    nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
    nginx: configuration file /etc/nginx/nginx.conf test is successful