### PR TITLE
Mount data subdirectory from postgresql container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     restart: always
     image: sameersbn/postgresql:10-2
     volumes:
-    - postgresql-data:/var/lib/postgresql:Z
+    - postgresql-data:/var/lib/postgresql/data:Z
     environment:
     - DB_USER=gitlab
     - DB_PASS=password


### PR DESCRIPTION
By mounting the `data/` subdirectory from the postgresql container, 
a startup issue with Docker on Windows is fixed, see 
https://stackoverflow.com/questions/41637505/how-to-persist-data-in-a-dockerized-postgres-database-using-volumes.