### PR TITLE
fix: test image curl uses ipv4 only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           name: Testing image
           command: |
             docker run --network container:$(docker-compose ps -q gitlab) \
-              appropriate/curl --retry 15 --retry-delay 5 --retry-connrefused http://localhost/explore
+              appropriate/curl --ipv4 --retry 15 --retry-delay 5 --retry-connrefused http://localhost/explore
 
       - run:
           name: Generate docker build image cache


### PR DESCRIPTION
* Despite the command running with --retry-connrefused, connections with ipv6 are not retried because it returns EADDRNOTAVAIL instead of ECONNREFUSED

Reference: https://github.com/appropriate/docker-curl/issues/5

```
~ $ docker run appropriate/curl --retry 15 --retry-delay 5 --retry-connrefused http://localhost/explore
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to localhost port 80: Connection refused


~ $ docker run appropriate/curl --ipv6 --retry 15 --retry-delay 5 --retry-connrefused http://localhost/explore
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Couldn't connect to server


~ $ docker run appropriate/curl --ipv4 --retry 15 --retry-delay 5 --retry-connrefused http://localhost/explore
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Transient problem: connection refused Will retry in 5 seconds. 15
Warning: retries left.
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Transient problem: connection refused Will retry in 5 seconds. 14
Warning: retries left.
```
Fixes CircleCI failing sometime 
* https://circleci.com/gh/sameersbn/docker-gitlab/1216
* https://circleci.com/gh/sameersbn/docker-gitlab/1214