### PR TITLE
feat: Add healthcheck for gitlab service

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@
     - [Import Repositories](#import-repositories)
     - [Upgrading](#upgrading)
     - [Shell Access](#shell-access)
-- [Features](#features)
- - [Container Registry](docs/container_registry.md)
+- [Monitoring](#monitoring)
+    - [Health Check](#health-check)
+- [Container Registry](docs/container_registry.md)
 - [References](#references)
 
 # Introduction
@@ -1331,6 +1332,48 @@ For debugging and maintenance purposes you may want access the containers shell.
 
 ```bash
 docker exec -it gitlab bash
+```
+
+# Monitoring
+
+You can monitor your GitLab instance status as described in the [official documentation](https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html), for example:
+
+```bash
+curl 'https://gitlab.example.com/-/liveness'
+```
+
+On success, the endpoint will return a `200` HTTP status code, and a response like below.
+
+```bash
+{
+   "status": "ok"
+}
+```
+
+To do that you will need to set the environment variable `GITLAB_MONITORING_IP_WHITELIST` to allow your IP or subnet to make requests to your GitLab instance.
+
+## Health Check
+
+You can also set your `docker-compose.yml` [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck) configuration to make periodic checks:
+
+```yml
+version: '2.3'
+
+services:
+  gitlab:
+    image: sameersbn/gitlab:12.7.7
+    healthcheck:
+      test: ["CMD", "/usr/local/sbin/healthcheck"]
+      interval: 1m
+      timeout: 5s
+      retries: 5
+      start_period: 2m
+```
+
+Then you will be able to consult the healthcheck log by executing:
+
+```bash
+docker inspect --format "{{json .State.Health }}" $(docker-compose ps -q gitlab) | jq
 ```
 
 # References

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -426,6 +426,16 @@ programs=sshd,nginx,mail_room,cron
 priority=20
 EOF
 
+# configure healthcheck script
+## https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html
+cat > /usr/local/sbin/healthcheck <<EOF
+#!/bin/bash
+url=http://localhost/-/liveness
+curl -s \$url
+[[ "\$(curl -s -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]
+EOF
+chmod +x /usr/local/sbin/healthcheck
+
 # purge build dependencies and cleanup apt
 DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${BUILD_DEPENDENCIES}
 rm -rf /var/lib/apt/lists/*

--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -1138,6 +1138,7 @@ production: &base
     # puma_sampler_interval: 5
     # IP whitelist to access monitoring endpoints
     ip_whitelist:
+      - 127.0.0.0/8
       - {{GITLAB_MONITORING_IP_WHITELIST}}
 
     # Sidekiq exporter is webserver built in to Sidekiq to expose Prometheus metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 
 services:
   redis:
@@ -31,6 +31,12 @@ services:
     - "10022:22"
     volumes:
     - gitlab-data:/home/git/data:Z
+    healthcheck:
+      test: ["CMD", "/usr/local/sbin/healthcheck"]
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 5m
     environment:
     - DEBUG=false
 


### PR DESCRIPTION
This PR adds support for health checking for gitlab service.

You can establish the `healthcheck` configuration in your `docker-compose.yml` file like in the following example:

```yml
version: '2.3'

services:
  gitlab:
    image: sameersbn/gitlab:12.7.7
    restart: always
    healthcheck:
      interval: 1m
      timeout: 5s
      retries: 5
      start_period: 2m
```

`healthcheck` can be configured for `redis` and `postgresql` services too:

```yml
version: '2.3'

services:
  redis:
    image: sameersbn/redis:4.0.9-3
    restart: always
    healthcheck:
      test: ["CMD", "redis-cli", "ping"]
      interval: 5s
      timeout: 5s
      retries: 10

  postgresql:
    image: sameersbn/postgresql:10-2
    restart: always
    healthcheck:
      test: ["CMD", "pg_isready"]
      interval: 5s
      timeout: 5s
      retries: 10
```

Then you can consult your container health check log like this:

```bash
docker inspect --format "{{json .State.Health }}" $(docker-compose ps -q gitlab) | jq
```

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2020-03-21T18:15:52.003997095+01:00",
      "End": "2020-03-21T18:15:52.157653221+01:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2020-03-21T18:16:52.217418564+01:00",
      "End": "2020-03-21T18:16:52.369393342+01:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2020-03-21T18:17:52.408288294+01:00",
      "End": "2020-03-21T18:17:52.58028274+01:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2020-03-21T18:18:52.628412275+01:00",
      "End": "2020-03-21T18:18:52.783658023+01:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2020-03-21T18:19:52.798689591+01:00",
      "End": "2020-03-21T18:19:52.971628586+01:00",
      "ExitCode": 0,
      "Output": ""
    }
  ]
}
```

Also, `docker ps` will tell you the state of your containers:

```
CONTAINER ID        IMAGE                            COMMAND                  CREATED             STATUS                    NAMES
f1214c128483        sameersbn/gitlab:latest          "/sbin/entrypoint.sh…"   40 minutes ago      Up 40 minutes (healthy)   gitlab_ce
9a1acae87880        sameersbn/redis:4.0.9-3          "/sbin/entrypoint.sh…"   40 minutes ago      Up 40 minutes (healthy)   gitlab_redis
021f452e1ae1        sameersbn/postgresql:10-2        "/sbin/entrypoint.sh"    40 minutes ago      Up 40 minutes (healthy)   gitlab_postgresql
```

Finally, you can use [willfarrell/autoheal](https://hub.docker.com/r/willfarrell/autoheal/) container to monitor and restart your unhealthy containers.

```bash
docker run -d \
    --name autoheal \
    --restart=always \
    -e AUTOHEAL_CONTAINER_LABEL=all \
    -v /var/run/docker.sock:/var/run/docker.sock \
    willfarrell/autoheal
```

⚠️ **Warning**: Too frequent checks can derive into a low disk performance by generating too much logs. **This seems to solve if you use docker volumes instead of mounting host directories directly**