### PR TITLE
Fix accidental replacement if no backup is configured

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -868,7 +868,7 @@ gitlab_configure_backups() {
     GITLAB_BACKUP_ARCHIVE_PERMISSIONS
   gitlab_configure_backups_schedule
   if [[ ${AWS_BACKUPS} != true && ${GCS_BACKUPS} != true ]]; then
-    exec_as_git sed -i "/\s\+upload:/,/#end-gcs/d" ${GITLAB_CONFIG}
+    exec_as_git sed -i "/\s\+#start-aws/,/#end-gcs/d" ${GITLAB_CONFIG}
     return 0
   fi
   if [[ ${AWS_BACKUPS} == true && ${GCS_BACKUPS} == true ]]; then


### PR DESCRIPTION
If none of AWS or GCS backups are configured, sed command would accidentially replace the second "upload:" occurrence until the end of file.