### PR TITLE
fix: Support for healthcheck with GITLAB_HTTPS=true

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -431,8 +431,9 @@ EOF
 cat > /usr/local/sbin/healthcheck <<EOF
 #!/bin/bash
 url=http://localhost/-/liveness
-curl -s \$url
-[[ "\$(curl -s -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]
+options=( '--insecure' '--location' '--silent' )
+curl "\${options[@]}" \$url
+[[ "\$(curl \${options[@]} -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]
 EOF
 chmod +x /usr/local/sbin/healthcheck
 


### PR DESCRIPTION
As reported on https://github.com/sameersbn/docker-gitlab/pull/2102#issuecomment-634521546, when `GITLAB_HTTPS=true`, `/usr/local/sbin/healthcheck` does not work properly because of an unfollow redirection.

As proposed by @cwildfoerster I have added `--insecure` and `--location` to the `curl` command to solve this issue:

- `--location`: Follow redirects
- `--insecure`: Allow connections to SSL sites without certs

Please @cwildfoerster, could you check that this fix solves the issue?

Current output of `docker inspect --format "{{json .State.Health }}" $(docker-compose ps -q gitlab) | jq` with the patch applied:

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2020-05-27T16:39:47.584519244+02:00",
      "End": "2020-05-27T16:39:47.791767891+02:00",
      "ExitCode": 0,
      "Output": "{\"status\":\"ok\"}"
    },
    {
      "Start": "2020-05-27T16:41:47.915243885+02:00",
      "End": "2020-05-27T16:41:48.115870548+02:00",
      "ExitCode": 0,
      "Output": "{\"status\":\"ok\"}"
    },
    {
      "Start": "2020-05-27T16:43:48.157659247+02:00",
      "End": "2020-05-27T16:43:48.346045525+02:00",
      "ExitCode": 0,
      "Output": "{\"status\":\"ok\"}"
    },
    {
      "Start": "2020-05-27T16:45:48.360112584+02:00",
      "End": "2020-05-27T16:45:48.549325324+02:00",
      "ExitCode": 0,
      "Output": "{\"status\":\"ok\"}"
    },
    {
      "Start": "2020-05-27T16:47:48.616220295+02:00",
      "End": "2020-05-27T16:47:48.815442552+02:00",
      "ExitCode": 0,
      "Output": "{\"status\":\"ok\"}"
    }
  ]
}
```