### PR TITLE
Swarm compose v3.4

### DIFF
--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -76,12 +76,12 @@ services:
     volumes:
     - gitlab-data:/home/git/data:Z
     - certs-data:/certs
-    healthcheck:
-      test: ["CMD", "/usr/local/sbin/healthcheck"]
-      interval: 5m
-      timeout: 10s
-      retries: 3
-      start_period: 5m
+    # healthcheck:
+    #   test: ["CMD", "/usr/local/sbin/healthcheck"]
+    #   interval: 5m
+    #   timeout: 10s
+    #   retries: 3
+    #   start_period: 5m
     networks:
       # To communicate with other services in this stack
       - default

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.4'
 services:
   redis:
     image: redis:5.0.9


### PR DESCRIPTION
Fix Docker Compose version for Docker Swarm mode, use 3.4 so that the healthcheck `start_period` is available.

Also, comment out the healthcheck section until it is built into the image and can be tested properly.

This should sove/related to #2164 