### PR TITLE
Obfuscate access_token and private_token in nginx access log

### DIFF
--- a/assets/runtime/config/nginx/gitlab
+++ b/assets/runtime/config/nginx/gitlab
@@ -25,6 +25,15 @@ map $http_upgrade $connection_upgrade_gitlab {
     ''      close;
 }
 
+## Obfuscate access_token and private_token in access log
+map $request_uri $obfuscated_request_uri {
+    ~(.+\?)(.*&)?(private_token=|access_token=)[^&]*(&.*|$) $1$2$3****$4;
+    default $request_uri;
+}
+log_format main '$remote_addr - $remote_user [$time_local] '
+                  '"$request_method $obfuscated_request_uri $server_protocol" $status $body_bytes_sent '
+                  '"$http_referer" "$http_user_agent"';
+
 ## Normal HTTP host
 server {
   ## Either remove "default_server" from the listen line below,
@@ -49,7 +58,7 @@ server {
   add_header Strict-Transport-Security "max-age={{NGINX_HSTS_MAXAGE}};";
 
   ## Individual nginx logs for this GitLab vhost
-  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log;
+  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log main;
   error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_error.log;
 
   location / {

--- a/assets/runtime/config/nginx/gitlab-ssl
+++ b/assets/runtime/config/nginx/gitlab-ssl
@@ -29,6 +29,15 @@ map $http_upgrade $connection_upgrade_gitlab_ssl {
     ''      close;
 }
 
+## Obfuscate access_token and private_token in access log
+map $request_uri $obfuscated_request_uri {
+    ~(.+\?)(.*&)?(private_token=|access_token=)[^&]*(&.*|$) $1$2$3****$4;
+    default $request_uri;
+}
+log_format main '$remote_addr - $remote_user [$time_local] '
+                  '"$request_method $obfuscated_request_uri $server_protocol" $status $body_bytes_sent '
+                  '"$http_referer" "$http_user_agent"';
+
 ## Redirects all HTTP traffic to the HTTPS host
 server {
   ## Either remove "default_server" from the listen line below,
@@ -40,7 +49,7 @@ server {
   server_name _; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
   return 301 https://$host:{{GITLAB_PORT}}$request_uri;
-  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log;
+  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log main;
   error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_error.log;
 }
 
@@ -94,7 +103,7 @@ server {
   ssl_dhparam {{SSL_DHPARAM_PATH}};
 
   ## Individual nginx logs for this GitLab vhost
-  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log;
+  access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_access.log main;
   error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_error.log;
 
   location / {


### PR DESCRIPTION
Authentication tokens are allowed to be part of URI and therefore they are printed
in the access log. This can be a security concern especially when system and
application logs are being sent to an external logging system (syslog, wazuh,
splunk, etc.).

This change masks values of these parameters in the access log.

**Before:**
```
2020-06-07T19:16:27-07:00 gitlab-gitlab-prod-001 gitlab-nginx-gitlab_access-log 174.20.228.117 - - 
[07/Jun/2020:19:16:20 -0700] "GET /api/v4/merge_requests/?access_token=abcd1234&per_page=10&scope=all&order_by=updated_at&sort=desc&page=1 HTTP/1.1" 401 118 "-" "Apache-HttpClient/4.5.11 (Java/11.0.6)"
```
**After:**
```
2020-06-07T19:16:27-07:00 gitlab-gitlab-prod-001 gitlab-nginx-gitlab_access-log 174.20.228.117 - - 
[07/Jun/2020:19:16:20 -0700] "GET /api/v4/merge_requests/?access_token=****&per_page=10&scope=all&order_by=updated_at&sort=desc&page=1 HTTP/1.1" 401 118 "-" "Apache-HttpClient/4.5.11 (Java/11.0.6)"
```

