### PR TITLE
Reduce container image size

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -135,6 +135,7 @@ chown -R ${GITLAB_USER}: ${GITLAB_GITALY_INSTALL_DIR}
 rm -rf ${GITLAB_GITALY_BUILD_DIR}
 
 # remove go
+go clean --modcache
 rm -rf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-amd64.tar.gz ${GOROOT}
 
 # remove HSTS config from the default headers, we configure it in nginx
@@ -443,3 +444,4 @@ rm -rf /var/lib/apt/lists/*
 
 # clean up caches
 rm -rf ${GITLAB_HOME}/.cache ${GITLAB_HOME}/.bundle ${GITLAB_HOME}/go
+rm -rf /root/.cache /root/.bundle ${GITLAB_HOME}/gitlab/node_modules


### PR DESCRIPTION
The Gitlab container image is massive. This PR removes unused caches and node_modules from the final image.

The 13.5.3 image on quay.io is 1.6GB, with these changes it should be ~950MB.
 
I have been running this change on my instance for 2 months and have not noticed any issues.
