### PR TITLE
Upgrade Redis in README to redis:6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ Step 2. Launch a redis container
 
 ```bash
 docker run --name gitlab-redis -d \
-    --volume /srv/docker/gitlab/redis:/var/lib/redis \
-    redis:5.0.9
+    --volume /srv/docker/gitlab/redis:/data \
+    redis:6.2
 ```
 
 Step 3. Launch the gitlab container
@@ -354,20 +354,20 @@ docker run --name gitlab -it --rm \
 
 You can link this image with a redis container to satisfy gitlab's redis requirement. The alias of the redis server container should be set to **redisio** while linking with the gitlab image.
 
-To illustrate linking with a redis container, we will use the [sameersbn/redis](https://github.com/sameersbn/docker-redis) image. Please refer the [README](https://github.com/sameersbn/docker-redis/blob/master/README.md) of docker-redis for details.
+To illustrate linking with a redis container, we will use the [redis](https://github.com/docker-library/redis) image. Please refer the [README](https://github.com/docker-library/docs/blob/master/redis/README.md) for details.
 
 First, lets pull the redis image from the docker index.
 
 ```bash
-docker pull redis:5.0.9
+docker pull redis:6.2
 ```
 
 Lets start the redis container
 
 ```bash
 docker run --name gitlab-redis -d \
-    --volume /srv/docker/gitlab/redis:/var/lib/redis \
-    redis:5.0.9
+    --volume /srv/docker/gitlab/redis:/data \
+    redis:6.2
 ```
 
 We are now ready to start the GitLab application.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Step 2. Launch a redis container
 ```bash
 docker run --name gitlab-redis -d \
     --volume /srv/docker/gitlab/redis:/var/lib/redis \
-    sameersbn/redis:4.0.9-2
+    redis:5.0.9
 ```
 
 Step 3. Launch the gitlab container
@@ -359,7 +359,7 @@ To illustrate linking with a redis container, we will use the [sameersbn/redis](
 First, lets pull the redis image from the docker index.
 
 ```bash
-docker pull sameersbn/redis:4.0.9-2
+docker pull redis:5.0.9
 ```
 
 Lets start the redis container
@@ -367,7 +367,7 @@ Lets start the redis container
 ```bash
 docker run --name gitlab-redis -d \
     --volume /srv/docker/gitlab/redis:/var/lib/redis \
-    sameersbn/redis:4.0.9-2
+    redis:5.0.9
 ```
 
 We are now ready to start the GitLab application.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2.3'
 services:
   redis:
     restart: always
-    image: redis:5.0.9
+    image: redis:6.2
     command:
     - --loglevel warning
     volumes:
-    - redis-data:/var/lib/redis:Z
+    - redis-data:/data:Z
 
   postgresql:
     restart: always

--- a/docs/s3_compatible_storage.md
+++ b/docs/s3_compatible_storage.md
@@ -72,11 +72,11 @@ version: '2'
 services:
   redis:
     restart: always
-    image: sameersbn/redis:4.0.9-2
+    image: sameersbn/redis:6.2
     command:
     - --loglevel warning
     volumes:
-    - /tmp/docker/gitlab/redis:/var/lib/redis:Z
+    - /tmp/docker/gitlab/redis:/data:Z
 
   postgresql:
     restart: always


### PR DESCRIPTION
Since 13.0.0, docker-compose.yml uses `redis:5.0.9` for Redis. 
Therefore,  I think it is better to match the README version as well.