### PR TITLE
Support healthcheck with relative URL

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -423,17 +423,6 @@ programs=sshd,nginx,mail_room,cron
 priority=20
 EOF
 
-# configure healthcheck script
-## https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html
-cat > /usr/local/sbin/healthcheck <<EOF
-#!/bin/bash
-url=http://localhost/-/liveness
-options=( '--insecure' '--location' '--silent' )
-curl "\${options[@]}" \$url
-[[ "\$(curl \${options[@]} -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]
-EOF
-chmod +x /usr/local/sbin/healthcheck
-
 # purge build dependencies and cleanup apt
 DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${BUILD_DEPENDENCIES}
 rm -rf /var/lib/apt/lists/*

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1523,6 +1523,19 @@ update_ssh_listen_port() {
   sed -i "s|#Port 22|Port ${GITLAB_SSH_LISTEN_PORT}|g" /etc/ssh/sshd_config
 }
 
+generate_healthcheck_script() {
+  # configure healthcheck script
+  ## https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html
+cat > /usr/local/sbin/healthcheck <<EOF
+#!/bin/bash
+url=http://localhost${GITLAB_RELATIVE_URL_ROOT}/-/liveness
+options=( '--insecure' '--location' '--silent' )
+curl "\${options[@]}" \$url
+[[ "\$(curl \${options[@]} -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]
+EOF
+  chmod +x /usr/local/sbin/healthcheck
+}
+
 initialize_system() {
   map_uidgid
   initialize_logdir
@@ -1665,6 +1678,7 @@ configure_gitlab() {
   gitlab_configure_registry
   gitlab_configure_pages
   gitlab_configure_sentry
+  generate_healthcheck_script
 
   # remove stale gitlab.socket
   rm -rf ${GITLAB_INSTALL_DIR}/tmp/sockets/gitlab.socket


### PR DESCRIPTION
partially solves #2337 .

Current healthcheck script (which run `curl http://localhost/-/liveness`) always reports unhealthy in the case relative URL in use.  
This script is [generated on build time](https://github.com/sameersbn/docker-gitlab/blob/82630d2d93e424467c1ab9d5f43918f1a8ba023a/assets/build/install.sh#L426-L435), and never updated. So if the user set `GITLAB_RELATIVE_URL_ROOT`, URL mismatch will happen and returns 404.

This PR transplants script generation to runtime to allow us to use `${GITLAB_RELATIVE_URL_ROOT}` variable to set healthcheck URL .
Nothing will happen for those who don't use relative URL since the variable will be replaced by empty string.

example output (`GITLAB_RELATIVE_URL: /gitlab` in docker-compose.yml)

```
$ docker exec -it gitlab /bin/bash
git@0468dd640abe: /home/git/gitlab# cat /usr/local/sbin/healthcheck
#!/bin/bash
url=http://localhost/gitlab-/liveness
options=( '--insecure' '--location' '--silent' )
curl "${options[@]}" $url
[[ "$(curl ${options[@]} -o /dev/null -I -w '%{http_code}' $url)" == "200" ]]
```

This is first time I submit a PR for this repository, so please let me know if I'm doing something weird.