### PR TITLE
Fixed Pages config not being created when GITLAB_PAGES_ACCESS_CONTROL was disabled

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1849,11 +1849,21 @@ if [[ ${GITLAB_PAGES_ACCESS_CONTROL} == true ]]; then
   else
     exec_as_git sed -i "/{{GITLAB_PAGES_ARTIFACTS_SERVER_URL}}/d" ${GITLAB_PAGES_CONFIG}
   fi
+else
+  update_template ${GITLAB_PAGES_CONFIG} \
+      GITLAB_INSTALL_DIR
+
+  exec_as_git sed -i "/{{GITLAB_PAGES_ACCESS_CLIENT_ID}}/d" ${GITLAB_PAGES_CONFIG}
+  exec_as_git sed -i "/{{GITLAB_PAGES_ACCESS_CLIENT_SECRET}}/d" ${GITLAB_PAGES_CONFIG}
+  exec_as_git sed -i "/{{GITLAB_PAGES_ACCESS_REDIRECT_URI}}/d" ${GITLAB_PAGES_CONFIG}
+  exec_as_git sed -i "/{{GITLAB_PAGES_ACCESS_SECRET}}/d" ${GITLAB_PAGES_CONFIG}
+  exec_as_git sed -i "/{{GITLAB_PAGES_ACCESS_CONTROL_SERVER}}/d" ${GITLAB_PAGES_CONFIG}
+  exec_as_git sed -i "/{{GITLAB_PAGES_ARTIFACTS_SERVER_URL}}/d" ${GITLAB_PAGES_CONFIG}
+fi
 
 cat >> /etc/supervisor/conf.d/gitlab-pages.conf <<EOF
   -config ${GITLAB_PAGES_CONFIG}
 EOF
-fi
 
 cat >> /etc/supervisor/conf.d/gitlab-pages.conf <<EOF
 user=git


### PR DESCRIPTION
Fixes this
https://github.com/sameersbn/docker-gitlab/issues/2375#issuecomment-886584314

Since v14.0, we will need at least `-internal-gitlab-server` and` -api-secret-key` of `gitlab-pages-config` with or without `GITLAB_PAGES_ACCESS_CONTROL`.

# Confirmation contents
I confirmed that the following files were created in the container with `GITLAB_PAGES_ACCESS_CONTROL` disabled. (Of course, GitLab Pages is also working!)

```bash
root@gitlab-dev:/home/git/gitlab# cat gitlab-pages-config
internal-gitlab-server=http://localhost:8181
api-secret-key=/home/git/gitlab/.gitlab_pages_secret

root@gitlab-dev:/home/git/gitlab# cat /etc/supervisor/conf.d/gitlab-pages.conf
[program:gitlab-pages]
priority=20
directory=/home/git/gitlab
environment=HOME=/home/git
command=/usr/local/bin/gitlab-pages
  -pages-domain gitlab-pages-prestage.misoshi.ru
  -pages-root /home/git/data/shared/pages
  -listen-proxy :8090
  -config /home/git/gitlab/gitlab-pages-config
user=git
autostart=true
autorestart=true
stdout_logfile=/home/git/gitlab/log/%(program_name)s.log
stderr_logfile=/home/git/gitlab/log/%(program_name)s.log
```