### PR TITLE
Revert "fix: Stop all process before sending SIGTERM to supervisor. (#2422)"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,6 @@ case ${1} in
         /usr/bin/supervisord -nc /etc/supervisor/supervisord.conf &
         SUPERVISOR_PID=$!
         migrate_database
-        /usr/bin/supervisorctl stop all
         kill -15 $SUPERVISOR_PID
         if ps h -p $SUPERVISOR_PID > /dev/null ; then
         wait $SUPERVISOR_PID || true


### PR DESCRIPTION
This reverts commit 3778a7abb1ac7c603288735547821f6610da07be, since the behavior described in #2421 appears to be caused  by applying the patch on systems that have not previously exhibited this error.

Therefore, another solution to the problem must be found. (The solution seemed plausible, but after applying the PR #2468 #2422, the problems described in #2421 appeared on previously normally operating systems).