### PR TITLE
Disable sourcemaps generation to fix "EMFILE: too many open files" er…Disable sourcemaps generation to fix "EMFILE: too many open files" error #2491

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -184,7 +184,7 @@ exec_as_git yarn install --production --pure-lockfile
 exec_as_git yarn add ajv@^4.0.0
 
 echo "Compiling assets. Please be patient, this could take a while..."
-exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true NODE_OPTIONS="--max-old-space-size=4096"
+exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true NO_SOURCEMAPS=true NODE_OPTIONS="--max-old-space-size=4096"
 
 # remove auto generated ${GITLAB_DATA_DIR}/config/secrets.yml
 rm -rf ${GITLAB_DATA_DIR}/config/secrets.yml


### PR DESCRIPTION
Hello @sachilles, 

here is a patch to disable sourcemaps generation to fix "EMFILE: too many open files" error #2491

What do you think?

Best regards,
Stéphane