### PR TITLE
add terraform/packages dir to initialize_datadir()

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1501,11 +1501,25 @@ initialize_datadir() {
   chmod u+rwX ${GITLAB_LFS_OBJECTS_DIR}
   chown ${GITLAB_USER}: ${GITLAB_LFS_OBJECTS_DIR}
 
+  # create terraform_state directory
+  # TODO : parametarize path and replace with it (e.g. GITLAB_TERRAFORM_STATE_STORAGE_PATH) - see sameersbn/gitlab#2438
+  # TODO : wrap with "if [[ _ENABLED == true ]]" condition
+  mkdir -p ${GITLAB_SHARED_DIR}/terraform_state
+  chmod u+rwX ${GITLAB_SHARED_DIR}/terraform_state
+  chown ${GITLAB_USER}: ${GITLAB_SHARED_DIR}/terraform_state
+
   # create registry dir
   if [[ ${GITLAB_REGISTRY_ENABLED} == true ]]; then
     mkdir -p ${GITLAB_REGISTRY_DIR}
     chmod u+rwX ${GITLAB_REGISTRY_DIR}
     chown ${GITLAB_USER}: ${GITLAB_REGISTRY_DIR}
+  fi
+
+  # create packages directory
+  if [[ ${GITLAB_PACKAGES_ENABLED} == true ]]; then
+    mkdir -p ${GITLAB_PACKAGES_DIR}
+    chmod u+rwX ${GITLAB_PACKAGES_DIR}
+    chown ${GILTAB_USER}: ${GITLAB_PACKAGES_DIR}
   fi
 
   # create the backups directory
@@ -1574,9 +1588,19 @@ sanitize_datadir() {
   chmod -R u+rwX ${GITLAB_LFS_OBJECTS_DIR}
   chown -R ${GITLAB_USER}: ${GITLAB_LFS_OBJECTS_DIR}
 
+  # create terraform_state directory
+  # TODO : wrap with "if [[ _ENABLED ]]" condition
+  chmod u+rwX ${GITLAB_SHARED_DIR}/terraform_state
+  chown ${GITLAB_USER}: ${GITLAB_SHARED_DIR}/terraform_state
+
   if [[ ${GITLAB_REGISTRY_ENABLED} == true ]]; then
     chmod -R u+rwX ${GITLAB_REGISTRY_DIR}
     chown -R ${GITLAB_USER}: ${GITLAB_REGISTRY_DIR}
+  fi
+
+  if [[ ${GITLAB_PACKAGES_ENABLED} ]]; then
+    chmod u+rwX ${GITLAB_PACKAGES_DIR}
+    chown ${GILTAB_USER}: ${GITLAB_PACKAGES_DIR}
   fi
 
   find ${GITLAB_DATA_DIR}/uploads -type f -exec chmod 0644 {} \;


### PR DESCRIPTION
Also add them to `sanitize_datadir()`

In GitLab 14.7.0, backup now contains [terraform state](https://about.gitlab.com/releases/2022/01/22/gitlab-14-7-released/#backup-and-restore-supports-terraform-state-files) and [package registry files](https://about.gitlab.com/releases/2022/01/22/gitlab-14-7-released/#backup-and-restore-supports-package-registry-files). 
The backup task will fail if these directories do not exist with each feature enabled. Currently `terraform_state` is [enabled by default](https://github.com/sameersbn/docker-gitlab/blob/c8d21133c1e40f39388cbc34874077ef410b02e5/assets/runtime/config/gitlabhq/gitlab.yml#L374), user cannot change this from environment variables like `GITLAB_TERRAFORM_STATE_ENABLED`.

Note: path for terraform state is not parameterized. PR is on #2438 so we have to replace the path with parameterized one if the PR is accepted.

> 