### PR TITLE
Use persisted host key path for `SSH_ALGORITHMS_PATH`

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -158,6 +158,9 @@ exec_as_git sed -i "/headers\['Strict-Transport-Security'\]/d" ${GITLAB_INSTALL_
 # revert `rake gitlab:setup` changes from gitlabhq/gitlabhq@a54af831bae023770bf9b2633cc45ec0d5f5a66a
 exec_as_git sed -i 's/db:reset/db:setup/' ${GITLAB_INSTALL_DIR}/lib/tasks/gitlab/setup.rake
 
+# change SSH_ALGORITHM_PATH - we have moved host keys in ${GITLAB_DATA_DIR}/ssh/ to persist them
+exec_as_git sed -i "s:/etc/ssh/:/${GITLAB_DATA_DIR}/ssh/:g" ${GITLAB_INSTALL_DIR}/app/models/instance_configuration.rb
+
 cd ${GITLAB_INSTALL_DIR}
 
 # install gems, use local cache if available


### PR DESCRIPTION
The host key information display feature on the help page was added a few years ago (see https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/13850). This feature assumes that the [SSH host key is in `/etc/ssh/`](https://gitlab.com/gitlab-org/gitlab/-/commit/294f40e2c8f51239bfa0e3514e7fe4f3c8ae00cb#3336eb0b7bbb4ccd62c46eb870de860bbe27d57b_0_5) and interferes with the approach we are taking to [persist the SSH host key](https://github.com/sameersbn/docker-gitlab/blob/c8d21133c1e40f39388cbc34874077ef410b02e5/assets/runtime/functions#L1596-L1611).  

This PR add the process during build process to modify the  `SSH_ALGORITHMS_PATH` in the gitlab's source to point our persisted ssh host key path.