### PR TITLE
add `prometheus_multiproc_dir` environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ COPY assets/runtime/ ${GITLAB_RUNTIME_DIR}/
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
+ENV prometheus_multiproc_dir="/dev/shm"
+
 ARG BUILD_DATE
 ARG VCS_REF
 


### PR DESCRIPTION
This PR adds `prometheus_multiproc_dir` environment variable as reported by @shiresn in #2387  
The value is `/dev/shm`. User can adjust its size (`--shm-size` for `docker run` option, or `shm_size` for docker-compose.yml. See [docker document](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources))

Closes #2387  
Closes #2397