### PR TITLE
Fix: HealthCheck Script will Fail if the ENV GITLAB_HTTPS set True

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1641,9 +1641,13 @@ update_ssh_listen_port() {
 generate_healthcheck_script() {
   # configure healthcheck script
   ## https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html
+  local HEALTHCHECK_PROTOCOL="http"
+  if [[ "${GITLAB_HTTPS}" == true ]]; then
+    HEALTHCHECK_PROTOCOL="${HEALTHCHECK_PROTOCOL}s"
+  fi
 cat > /usr/local/sbin/healthcheck <<EOF
 #!/bin/bash
-url=http://localhost${GITLAB_RELATIVE_URL_ROOT}/-/liveness
+url=${HEALTHCHECK_PROTOCOL}://localhost${GITLAB_RELATIVE_URL_ROOT}/-/liveness
 options=( '--insecure' '--location' '--silent' )
 curl "\${options[@]}" \$url
 [[ "\$(curl \${options[@]} -o /dev/null -I -w '%{http_code}' \$url)" == "200" ]]


### PR DESCRIPTION
The liveness probe request will return a 302 redirect status code when enable https endpoint,
Which will cause a misleading healthcheck result.
![Capture](https://user-images.githubusercontent.com/1256540/155827005-045e910b-1b6a-4ff6-a69b-8ecd41efd1c4.PNG)
