### PR TITLE
Update `bundler` from 2.1.4 to 2.3.6

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -90,6 +90,10 @@ fi
 GITLAB_SHELL_VERSION=${GITLAB_SHELL_VERSION:-$(cat ${GITLAB_INSTALL_DIR}/GITLAB_SHELL_VERSION)}
 GITLAB_PAGES_VERSION=${GITLAB_PAGES_VERSION:-$(cat ${GITLAB_INSTALL_DIR}/GITLAB_PAGES_VERSION)}
 
+# install bundler: use version specified in Gemfile.lock
+BUNDLER_VERSION="$(grep "BUNDLED WITH" ${GITLAB_INSTALL_DIR}/Gemfile.lock -A 1 | grep -v "BUNDLED WITH" | tr -d "[:space:]")"
+gem install bundler:"${BUNDLER_VERSION}" 
+
 # download golang
 echo "Downloading Go ${GOLANG_VERSION}..."
 wget -cnv https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz -P ${GITLAB_BUILD_DIR}/


### PR DESCRIPTION
`bundler` used in gitlab is upgraded from 2.1.4 to 2.3.6
See more detail on : https://gitlab.com/gitlab-org/gitlab/-/merge_requests/79251
first contained tag : v14.8.0

````sh
$ git tag --contains 6010918f
v14.8.0-ee
v14.8.0-rc42-ee
v14.8.1-ee
v14.8.2-ee
v14.8.3-ee
v14.8.4-ee
v14.8.5-ee
v14.9.0-ee
v14.9.0-rc42-ee
v14.9.1-ee
v14.9.2-ee
v14.9.3-ee
````

This pull request modifies `assets/build/install.sh` to check the version of `bundler` used to generate Gemfile.lock and make sure to install the correct version.