### PR TITLE
refs #2549: Install git from gitaly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,11 @@ RUN set -ex && \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
       sudo supervisor logrotate locales curl \
       nginx openssh-server postgresql-client-12 postgresql-contrib-12 redis-tools \
-      git-core python3 python3-docutils nodejs yarn gettext-base graphicsmagick \
+      python3 python3-docutils nodejs yarn gettext-base graphicsmagick \
       libpq5 zlib1g libyaml-0-2 libssl1.1 \
       libgdbm6 libreadline8 libncurses5 libffi7 \
       libxml2 libxslt1.1 libcurl4 libicu66 libre2-dev tzdata unzip libimage-exiftool-perl \
+      libcurl4-openssl-dev libexpat1-dev gettext libz-dev libssl-dev libpcre2-dev build-essential git-core \
       libmagic1 \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && locale-gen en_US.UTF-8 \

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -92,7 +92,7 @@ GITLAB_PAGES_VERSION=${GITLAB_PAGES_VERSION:-$(cat ${GITLAB_INSTALL_DIR}/GITLAB_
 
 # install bundler: use version specified in Gemfile.lock
 BUNDLER_VERSION="$(grep "BUNDLED WITH" ${GITLAB_INSTALL_DIR}/Gemfile.lock -A 1 | grep -v "BUNDLED WITH" | tr -d "[:space:]")"
-gem install bundler:"${BUNDLER_VERSION}" 
+gem install bundler:"${BUNDLER_VERSION}"
 
 # download golang
 echo "Downloading Go ${GOLANG_VERSION}..."
@@ -147,6 +147,10 @@ cp -a ${GITLAB_GITALY_BUILD_DIR}/ruby ${GITLAB_GITALY_INSTALL_DIR}/
 cp -a ${GITLAB_GITALY_BUILD_DIR}/config.toml.example ${GITLAB_GITALY_INSTALL_DIR}/config.toml
 rm -rf ${GITLAB_GITALY_INSTALL_DIR}/ruby/vendor/bundle/ruby/**/cache
 chown -R ${GITLAB_USER}: ${GITLAB_GITALY_INSTALL_DIR}
+
+# install git bundled with gitaly.
+make -C ${GITLAB_GITALY_BUILD_DIR} git GIT_PREFIX=/usr/local
+apt remove -y git-core
 
 # clean up
 rm -rf ${GITLAB_GITALY_BUILD_DIR}
@@ -456,4 +460,4 @@ rm -rf /var/lib/apt/lists/*
 # clean up caches
 rm -rf ${GITLAB_HOME}/.cache ${GITLAB_HOME}/.bundle ${GITLAB_HOME}/go
 rm -rf /root/.cache /root/.bundle ${GITLAB_HOME}/gitlab/node_modules
-rm -r /tmp/* 
+rm -r /tmp/*


### PR DESCRIPTION
Installing git as explained here: https://docs.gitlab.com/ee/install/installation.html#git

the idea is to use the gif client bundled with Gitaly and not the one provided by the distro