### PR TITLE
Set `*:object_store:enabled` in gitlab.yml regardless the value

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -980,6 +980,9 @@ gitlab_configure_ci() {
 }
 
 gitlab_configure_artifacts() {
+  update_template ${GITLAB_CONFIG} \
+    GITLAB_ARTIFACTS_OBJECT_STORE_ENABLED
+
   if [[ ${GITLAB_ARTIFACTS_OBJECT_STORE_ENABLED} == true ]]; then
     echo "Configuring gitlab::artifacts:object_store"
 
@@ -997,7 +1000,6 @@ gitlab_configure_artifacts() {
     fi
 
     update_template ${GITLAB_CONFIG} \
-      GITLAB_ARTIFACTS_OBJECT_STORE_ENABLED \
       GITLAB_ARTIFACTS_OBJECT_STORE_REMOTE_DIRECTORY \
       GITLAB_ARTIFACTS_OBJECT_STORE_DIRECT_UPLOAD \
       GITLAB_ARTIFACTS_OBJECT_STORE_BACKGROUND_UPLOAD \
@@ -1025,6 +1027,9 @@ gitlab_configure_artifacts() {
 
 
 gitlab_configure_packages() {
+  update_template ${GITLAB_CONFIG} \
+    GITLAB_PACKAGES_OBJECT_STORE_ENABLED
+
   if [[ ${GITLAB_PACKAGES_OBJECT_STORE_ENABLED} == true ]]; then
     echo "Configuring gitlab::packages:object_store"
 
@@ -1042,7 +1047,6 @@ gitlab_configure_packages() {
     fi
 
     update_template ${GITLAB_CONFIG} \
-      GITLAB_PACKAGES_OBJECT_STORE_ENABLED \
       GITLAB_PACKAGES_OBJECT_STORE_REMOTE_DIRECTORY \
       GITLAB_PACKAGES_OBJECT_STORE_DIRECT_UPLOAD \
       GITLAB_PACKAGES_OBJECT_STORE_BACKGROUND_UPLOAD \
@@ -1069,6 +1073,9 @@ gitlab_configure_packages() {
 }
 
 gitlab_configure_terraform_state() {
+  update_template ${GITLAB_CONFIG} \
+    GITLAB_TERRAFORM_STATE_OBJECT_STORE_ENABLED
+  
   if [[ ${GITLAB_TERRAFORM_STATE_OBJECT_STORE_ENABLED} == true ]]; then
     echo "Configuring gitlab::terraform_state:object_store"
 
@@ -1086,7 +1093,6 @@ gitlab_configure_terraform_state() {
     fi
 
     update_template ${GITLAB_CONFIG} \
-      GITLAB_TERRAFORM_STATE_OBJECT_STORE_ENABLED \
       GITLAB_TERRAFORM_STATE_OBJECT_STORE_REMOTE_DIRECTORY \
       GITLAB_TERRAFORM_STATE_OBJECT_STORE_CONNECTION_PROVIDER \
       GITLAB_TERRAFORM_STATE_OBJECT_STORE_CONNECTION_AWS_ACCESS_KEY_ID \
@@ -1110,6 +1116,9 @@ gitlab_configure_terraform_state() {
 }
 
 gitlab_configure_lfs() {
+  update_template ${GITLAB_CONFIG} \
+    GITLAB_LFS_OBJECT_STORE_ENABLED \
+  
   if [[ ${GITLAB_LFS_OBJECT_STORE_ENABLED} == true ]]; then
     echo "Configuring gitlab::lfs:object_store"
 
@@ -1127,7 +1136,6 @@ gitlab_configure_lfs() {
     fi
 
     update_template ${GITLAB_CONFIG} \
-      GITLAB_LFS_OBJECT_STORE_ENABLED \
       GITLAB_LFS_OBJECT_STORE_REMOTE_DIRECTORY \
       GITLAB_LFS_OBJECT_STORE_DIRECT_UPLOAD \
       GITLAB_LFS_OBJECT_STORE_BACKGROUND_UPLOAD \
@@ -1154,6 +1162,9 @@ gitlab_configure_lfs() {
 }
 
 gitlab_configure_uploads() {
+  update_template ${GITLAB_CONFIG} \
+    GITLAB_UPLOADS_OBJECT_STORE_ENABLED
+
   if [[ ${GITLAB_UPLOADS_OBJECT_STORE_ENABLED} == true ]]; then
     echo "Configuring gitlab::uploads:object_store"
 
@@ -1171,7 +1182,6 @@ gitlab_configure_uploads() {
     fi
 
     update_template ${GITLAB_CONFIG} \
-      GITLAB_UPLOADS_OBJECT_STORE_ENABLED \
       GITLAB_UPLOADS_OBJECT_STORE_REMOTE_DIRECTORY \
       GITLAB_UPLOADS_OBJECT_STORE_DIRECT_UPLOAD \
       GITLAB_UPLOADS_OBJECT_STORE_BACKGROUND_UPLOAD \


### PR DESCRIPTION
In current code, `upload:object_store:enabled` is updated [only if `GITLAB_UPLOADS_OBJECT_STORE_ENABLED` is set to `true`](https://github.com/sameersbn/docker-gitlab/blob/1417c926360f553331f961e1177afe14cbccd615/assets/runtime/functions#L1157-L1190). It makes `puma` to die because of invalid value appears to configuration.  

This can be fixed by running `update_template GITLAB_UPLOADS_OBJECT_STORE_ENABLED` regardless of the value.

Here is a `/var/log/gitlab/supervisor/puma.log` that shows puma reporting exception.  

<details>
<summary>/var/log/gitlab/supervisor/puma.log</summary>

````sh
bundler: failed to load command: puma (/home/git/gitlab/vendor/bundle/ruby/2.7.0/bin/puma)
/home/git/gitlab/config/initializers/direct_upload_support.rb:22:in `verify!': Object storage provider '{"{\\"GITLAB_UPLOADS_OBJECT_STORE_CONNECTION_PROVIDER\\"=>nil}"=>nil}' is not supported when 'direct_upload' is used for 'lfs'. Only Google, AWS, and AzureRM are supported. (DirectUploadsValidator::ValidationError)
	from /home/git/gitlab/config/initializers/direct_upload_support.rb:45:in `block (2 levels) in <top (required)>'
	from /home/git/gitlab/config/initializers/direct_upload_support.rb:44:in `each'
	from /home/git/gitlab/config/initializers/direct_upload_support.rb:44:in `block in <top (required)>'
	from /home/git/gitlab/config/initializers/direct_upload_support.rb:37:in `tap'
	from /home/git/gitlab/config/initializers/direct_upload_support.rb:37:in `<top (required)>'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:681:in `load'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:681:in `block in load_config_initializer'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.7/lib/active_support/notifications.rb:205:in `instrument'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:680:in `load_config_initializer'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:634:in `block (2 levels) in <class:Engine>'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:633:in `each'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/engine.rb:633:in `block in <class:Engine>'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:32:in `instance_exec'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:32:in `run'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:50:in `each'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:50:in `tsort_each_child'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:415:in `call'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:415:in `each_strongly_connected_component_from'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `call'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/initializable.rb:60:in `run_initializers'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.7/lib/rails/application.rb:391:in `initialize!'
	from /home/git/gitlab/config/environment.rb:7:in `<top (required)>'
	from config.ru:5:in `require'
	from config.ru:5:in `block in <main>'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `eval'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `new_from_string'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:105:in `load_file'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:66:in `parse_file'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/configuration.rb:348:in `load_rackup'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/configuration.rb:270:in `app'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/runner.rb:150:in `load_and_bind'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/cluster.rb:357:in `run'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/launcher.rb:182:in `run'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/lib/puma/cli.rb:81:in `run'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/gems/puma-5.6.2/bin/puma:10:in `<top (required)>'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/bin/puma:23:in `load'
	from /home/git/gitlab/vendor/bundle/ruby/2.7.0/bin/puma:23:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli/exec.rb:58:in `load'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli/exec.rb:23:in `run'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli.rb:484:in `exec'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli.rb:31:in `dispatch'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/cli.rb:25:in `start'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/exe/bundle:48:in `block in <top (required)>'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.6/exe/bundle:36:in `<top (required)>'
	from /usr/local/bin/bundle:23:in `load'
	from /usr/local/bin/bundle:23:in `<main>'
````

</details>