### PR TITLE
Update docker command for sample Postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Step 1. Launch a postgresql container
 docker run --name gitlab-postgresql -d \
     --env 'DB_NAME=gitlabhq_production' \
     --env 'DB_USER=gitlab' --env 'DB_PASS=password' \
-    --env 'DB_EXTENSION=pg_trgm' \
+    --env 'DB_EXTENSION=pg_trgm,btree_gist' \
     --volume /srv/docker/gitlab/postgresql:/var/lib/postgresql \
     sameersbn/postgresql:12-20200524
 ```


### PR DESCRIPTION
As the default Postgresql version had been upgraded as version 12,  the sample command should be updating too, otherwise, we will meet permission issue during first execution.