### PR TITLE
Mount builds folder to runners

### DIFF
--- a/docs/docker-swarm-traefik-registry.md
+++ b/docs/docker-swarm-traefik-registry.md
@@ -368,7 +368,7 @@ gitlab-runner \
     --access-level not_protected \
     --builds-dir /tmp/builds \
     --docker-image docker:latest \
-    --docker-volumes /tmp/builds:/tmp/builds
+    --docker-volumes /tmp/builds:/tmp/builds \
     --docker-volumes /var/run/docker.sock:/var/run/docker.sock \
     --url $GITLAB_URL \
     --registration-token $GITLAB_TOKEN \

--- a/docs/docker-swarm-traefik-registry.md
+++ b/docs/docker-swarm-traefik-registry.md
@@ -331,6 +331,7 @@ docker run -d \
     --name gitlab-runner \
     --restart always \
     -v gitlab-runner:/etc/gitlab-runner \
+    -v /tmp/builds:/tmp/builds \
     -v /var/run/docker.sock:/var/run/docker.sock \
     gitlab/gitlab-runner:latest
 ```
@@ -363,7 +364,11 @@ gitlab-runner \
     register -n \
     --name "Docker Runner" \
     --executor docker \
+    --locked false \
+    --access-level not_protected \
+    --builds-dir /tmp/builds \
     --docker-image docker:latest \
+    --docker-volumes /tmp/builds:/tmp/builds
     --docker-volumes /var/run/docker.sock:/var/run/docker.sock \
     --url $GITLAB_URL \
     --registration-token $GITLAB_TOKEN \


### PR DESCRIPTION
In many situations, Docker runners must mount the builds folder to continue with a job, but this is not currently possible due to runner configurations. It is preferable to spare new users from any inconveniences since your repository is widely used.

References:
https://docs.gitlab.com/runner/register/#one-line-registration-command
https://docs.gitlab.com/ee/ci/testing/code_quality.html#improve-code-quality-performance-with-private-runners