### PR TITLE
Update supervisord configs

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -251,6 +251,10 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 # move supervisord.log file to ${GITLAB_LOG_DIR}/supervisor/
 sed -i "s|^[#]*logfile=.*|logfile=${GITLAB_LOG_DIR}/supervisor/supervisord.log ;|" /etc/supervisor/supervisord.conf
 
+# prevent confusing warning "CRIT Supervisor running as root" by clarify run as root
+#   user not defined in supervisord.conf by default, so just append it after [supervisord] block
+sed -i "/\[supervisord\]/a user=root" /etc/supervisor/supervisord.conf
+
 # move nginx logs to ${GITLAB_LOG_DIR}/nginx
 sed -i \
   -e "s|access_log /var/log/nginx/access.log;|access_log ${GITLAB_LOG_DIR}/nginx/access.log;|" \

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -353,8 +353,6 @@ command=bundle exec sidekiq -c {{SIDEKIQ_CONCURRENCY}}
   -C ${GITLAB_INSTALL_DIR}/config/sidekiq_queues.yml
   -e ${RAILS_ENV}
   -t {{SIDEKIQ_SHUTDOWN_TIMEOUT}}
-  -P ${GITLAB_INSTALL_DIR}/tmp/pids/sidekiq.pid
-  -L ${GITLAB_INSTALL_DIR}/log/sidekiq.log
 user=git
 autostart=true
 autorestart=true


### PR DESCRIPTION
This PR introduces following changes:

- Clarify "user=root" in supervisord.conf
  We can see warning message "CRIT: Supervisor running as root" on container startup. This is not harmful but may confuse user.  
  We can simply prevent this warning by clarifying user in supervisord.conf.  
  We also set `user` for each programs so I believe nothing happens.
- Update sidekiq startup command : remove deprecated options
  Sidekiq is updated to v6.0 here (first contained tag: v14.4.0-ee)
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/69655
  
  In Sidekiq 6.0, command line option `-P` (set pid file) and `-L` (set log file) have been marked as deprecated.
  See https://github.com/sidekiq/sidekiq/commit/3f5b1c5
  
  Now, we can see error message in {GITLAB_LOGS_DIR}/supervisor/sidekiq.log
  like below:

  ````
  ERROR: PID file creation was removed in Sidekiq 6.0, please use a proper process supervisor to start and manage your services
  ERROR: Logfile redirection was removed in Sidekiq 6.0, Sidekiq will only log to STDOUT
  ````

  Log file is managed by supervisor's STDOUT option. PID is also managed by supervisord. So we don't need to set them. Just stop using this option.