### PR TITLE
Avoid permission error on creating config file

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -193,7 +193,8 @@ exec_as_git cp ${GITLAB_INSTALL_DIR}/config/gitlab.yml.example ${GITLAB_INSTALL_
 # Temporary workaround, see <https://github.com/sameersbn/docker-gitlab/pull/2596>
 #
 # exec_as_git cp ${GITLAB_INSTALL_DIR}/config/database.yml.postgresql ${GITLAB_INSTALL_DIR}/config/database.yml
-exec_as_git cp ${GITLAB_BUILD_DIR}/config/database.yml.postgresql ${GITLAB_INSTALL_DIR}/config/database.yml
+cp ${GITLAB_BUILD_DIR}/config/database.yml.postgresql ${GITLAB_INSTALL_DIR}/config/database.yml
+chown ${GITLAB_USER}: ${GITLAB_INSTALL_DIR}/config/database.yml
 
 # Installs nodejs packages required to compile webpack
 exec_as_git yarn install --production --pure-lockfile


### PR DESCRIPTION
`assets/build/config/database.yml.postgresql` is owned by root:root, and permission is rwxrw----
so the user `git` (`${GILTAB_USER}`) doesn't have a permission to copy the file.
This raises an permission error while building image locally if the docker is running on rootless environment (or the user is just a member of `docker` group).

This PR avoids this kind of issue by first copying the file as root and then changing the owner to the `GITLAB_USER`.

