### PR TITLE
Allow SSH clients to explicitly set the Git transfer protocol

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -246,6 +246,7 @@ sed -i \
   -e "s|^[#]*LogLevel INFO|LogLevel VERBOSE|" \
   -e "s|^[#]*AuthorizedKeysFile.*|AuthorizedKeysFile %h/.ssh/authorized_keys %h/.ssh/authorized_keys_proxy|" \
   /etc/ssh/sshd_config
+echo "AcceptEnv GIT_PROTOCOL" >> /etc/ssh/sshd_config # Allow clients to explicitly set the Git transfer protocol, e.g. to enable version 2.
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
 # move supervisord.log file to ${GITLAB_LOG_DIR}/supervisor/


### PR DESCRIPTION
This allows to the client to explicitly select protocol version 2, which is much more efficient. Without allowing that environment variable it seems that SSH connections are always stuck in version1.  See https://docs.gitlab.com/ee/administration/git_protocol.html on how to check if protocol 2 is used.