### PR TITLE
Use `purge` instead to uninstall unused db clients

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -239,7 +239,7 @@ gitlab_uninstall_unused_database_client() {
     # remove unused client using regex above
     UNUSED_DB_CLIENTS=$(apt-cache pkgnames postgresql-client | grep -v -e "${REGEX_DB_CLIENT_VERSIONS_IN_USE}" | tr '\n' ' ')
     echo "- Uninstalling unused client(s): ${UNUSED_DB_CLIENTS}"
-    DEBIAN_FRONTEND=noninteractive apt-get -qq remove -- ${UNUSED_DB_CLIENTS} >/dev/null
+    DEBIAN_FRONTEND=noninteractive apt-get -qq purge -- ${UNUSED_DB_CLIENTS} >/dev/null
   fi
 }
 

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -239,7 +239,7 @@ gitlab_uninstall_unused_database_client() {
     # remove unused client using regex above
     UNUSED_DB_CLIENTS=$(apt-cache pkgnames postgresql-client | grep -v -e "${REGEX_DB_CLIENT_VERSIONS_IN_USE}" | tr '\n' ' ')
     echo "- Uninstalling unused client(s): ${UNUSED_DB_CLIENTS}"
-    DEBIAN_FRONTEND=noninteractive apt-get -qq purge -- ${UNUSED_DB_CLIENTS} >/dev/null
+    DEBIAN_FRONTEND=noninteractive apt-get -qq -y purge -- ${UNUSED_DB_CLIENTS} >/dev/null
   fi
 }
 


### PR DESCRIPTION
In previous PR I have used `remove` to uninstall unused `postgresql-client`. It just uninstall the packages and does not actually remove files (configs, for example).  
The `pg_isready` command is executed when confirming the connection with the database. It was pointed out that by not using `purge`, an uninstalled version of the `pg_isready` command could be executed.

This PR change the command to be issued when uninstalling unused versions of `postgresql-client`.  

Thanks to reporting this issue @f-io : https://github.com/sameersbn/docker-gitlab/pull/2685#issuecomment-1560858104
