### PR TITLE
Fix unused client removal on restarted container

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -237,7 +237,16 @@ gitlab_uninstall_unused_database_client() {
     REGEX_DB_CLIENT_VERSIONS_IN_USE="-common${DB_CLIENT_VERSIONS_IN_USE}"
 
     # remove unused client using regex above
-    UNUSED_DB_CLIENTS=$(apt-cache pkgnames postgresql-client | grep -v -e "${REGEX_DB_CLIENT_VERSIONS_IN_USE}" | tr '\n' ' ')
+    # grep may return non-zero code on mo match, so fake the exit code with the `|| true` to swallow that
+    UNUSED_DB_CLIENTS=$(apt-cache pkgnames postgresql-client | grep -v -e "${REGEX_DB_CLIENT_VERSIONS_IN_USE}" || true)
+    if [[ "${UNUSED_DB_CLIENTS}" == "" ]]; then
+      echo "- All installed version of clients are in use. Did not uninstalled any client..."
+      return
+    fi
+
+    # just to get clean log, convert newline (package name delimiter) to single whitespace
+    UNUSED_DB_CLIENTS=$(echo ${UNUSED_DB_CLIENTS} | tr '\n' ' ')
+
     echo "- Uninstalling unused client(s): ${UNUSED_DB_CLIENTS}"
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y purge -- ${UNUSED_DB_CLIENTS} >/dev/null
   fi


### PR DESCRIPTION
Fix #2773 , followup #2685 I have submitted

Handle the case where the target does not exist in the process of deleting unused clients.
Such a situation will not occur in newly launched container, but will occur if it is restarted.

During container restarts, container status are preserved. If the unused database client was deleted, they will continue to be removed even after restarting. So `grep` to list up unused clients will not match anything.

And, `grep` returns non-zero code on nothing match. This stops container because entrypoint sets option `-e` (exit immediately on non-zero exit code excluding some special cases)

This PR make the uninstall process to handle the case UNUSED_DB_CLIENTS is empty - just do nothing then.