### PR TITLE
Update (fix) postgresql-client docs section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Configuring gitlab::database
 …
 ````
 
-Please note furthermore, that only combatible versions of the `postgresql-client` to GitLab are shipped with this image. Currently these belogn to
+Please note furthermore, that only compatible versions of the `postgresql-client` to GitLab are shipped with this image. Currently these belong to
 
 - `postgresql-client-13`,
 - `postgresql-client-14`,

--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ Configuring gitlab::database
 
 Please note furthermore, that only combatible versions of the `postgresql-client` to GitLab are shipped with this image. Currently these belogn to
 
-- `postgresql-client-12`,
 - `postgresql-client-13`,
 - `postgresql-client-14`,
 - and `postgresql-client-15`.


### PR DESCRIPTION
Package `postgresql-client-12` have been removed from default installed clients (#2678, especially fcd5297d5dab1f383383e5ff7826a4bda3e77f98). This PR simply apply it to README.

Also fixes some minor typo in docs added in #2685, especially b736b99.
