### PR TITLE
support arm architecture

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -98,8 +98,9 @@ gem install bundler:"${BUNDLER_VERSION}"
 
 # download golang
 echo "Downloading Go ${GOLANG_VERSION}..."
-wget -cnv https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz -P ${GITLAB_BUILD_DIR}/
-tar -xf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-amd64.tar.gz -C /tmp/
+dpkgArch="$(dpkg --print-architecture)"
+wget -cnv https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${dpkgArch}.tar.gz -P ${GITLAB_BUILD_DIR}/
+tar -xf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-${dpkgArch}.tar.gz -C /tmp/
 
 # install gitlab-shell
 echo "Downloading gitlab-shell v.${GITLAB_SHELL_VERSION}..."
@@ -164,7 +165,7 @@ rm -rf ${GITLAB_GITALY_BUILD_DIR}
 
 # remove go
 go clean --modcache
-rm -rf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-amd64.tar.gz ${GOROOT}
+rm -rf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-${dpkgArch}.tar.gz ${GOROOT}
 
 # remove HSTS config from the default headers, we configure it in nginx
 exec_as_git sed -i "/headers\['Strict-Transport-Security'\]/d" ${GITLAB_INSTALL_DIR}/app/controllers/application_controller.rb


### PR DESCRIPTION
To be able build not only amd64 images we need to support golang downloading for proper architecture.

Example:
docker buildx build --platform=linux/arm64 -t sameersbn/gitlab .

You can even adjust (in future) your automation builds to push multiarch builds to your docker registries. This is buildkit docker feature OOTB.