### PR TITLE
Upgrade nodejs apt source repo from 16.x to 18.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex && \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
- && echo 'deb https://deb.nodesource.com/node_16.x focal main' > /etc/apt/sources.list.d/nodesource.list \
+ && echo 'deb https://deb.nodesource.com/node_18.x focal main' > /etc/apt/sources.list.d/nodesource.list \
  && wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add - \
  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
  && set -ex \


### PR DESCRIPTION
Required version of node.js is updated from v16.15.0 to v18.16.0 with GitLab v16.1.0 release
- "Update required node version to 18.16.0 or later"  
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/106898

Then nodejs v18.16.1 with GitLab v16.2.0
- "Update Node.js to 18.16.1"
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/124802

And will be updated to v18.17.0 soon (not released yet, but already merged)
- "Update Node.js to 18.17.0"  
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/127560

This pull request simply change the apt source repository from node_16.x to node_18.x.