### PR TITLE
Accept multiple hosts for RACK_ATTACK_WHITELIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -2381,7 +2381,19 @@ Enable/disable rack middleware for blocking & throttling abusive requests Defaul
 
 ##### `RACK_ATTACK_WHITELIST`
 
-Always allow requests from whitelisted host. Defaults to `127.0.0.1`
+Always allow requests from whitelisted host.   
+This should be a valid yaml sequence of host address. Each host address string must be a valid IP address that can be passed to `IPAddr.new` of ruby. See [ruby-lang reference](https://docs.ruby-lang.org/en/3.0/IPAddr.html#method-c-new) for detail.  
+If you need to set multiple hosts, set this parameter like `["1.1.1.1","192.168.0.0/24"]` for example. In docker-compose.yml, you have to quote whole value like below:
+
+````yaml
+environment:
+# pattern 1: surround with single quote, double quote each IP address
+- RACK_ATTACK_WHITELIST='["1.1.1.1","192.168.0.0/24"]'
+# pattern 2: surround with double quote, single quote each IP address
+- RACK_ATTACK_WHITELIST="['1.1.1.1','192.168.0.0/24']"
+````
+
+Defaults to `["127.0.0.1"]`
 
 ##### `RACK_ATTACK_MAXRETRY`
 

--- a/assets/runtime/config/gitlabhq/gitlab.yml
+++ b/assets/runtime/config/gitlabhq/gitlab.yml
@@ -1231,7 +1231,7 @@ production: &base
       enabled: {{RACK_ATTACK_ENABLED}}
       #
       # Whitelist requests from 127.0.0.1 for web proxies (NGINX/Apache) with incorrect headers
-      ip_whitelist: ["{{RACK_ATTACK_WHITELIST}}"]
+      ip_whitelist: {{RACK_ATTACK_WHITELIST}}
       #
       # Limit the number of Git HTTP authentication attempts per IP
       maxretry: {{RACK_ATTACK_MAXRETRY}}

--- a/assets/runtime/env-defaults
+++ b/assets/runtime/env-defaults
@@ -544,7 +544,31 @@ PIWIK_SITE_ID=${PIWIK_SITE_ID:-}
 
 ## RACK ATTACK
 RACK_ATTACK_ENABLED=${RACK_ATTACK_ENABLED:-true}
-RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST:-"127.0.0.1"}
+RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST:-'["127.0.0.1"]'}
+RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST// /}
+# Backward compatibility : See sameersbn/docker-gitlab#2828
+# Pre-check: each host is surrounded by single / double quotation
+# if not, generated string will be [127.0.0.1] for example and ruby raises error
+RACK_ATTACK_WHITELIST_ORIGIN=${RACK_ATTACK_WHITELIST}
+# remove [], then iterate entries
+RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST#"["}
+RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST%"]"}
+IFS_ORG=${IFS}
+IFS=,
+for host in ${RACK_ATTACK_WHITELIST}; do
+  # Both single / double quotation may be used
+  if ! [[ ${host} =~ ^(\"|\').*(\"|\')$ ]]; then
+    RACK_ATTACK_WHITELIST=${RACK_ATTACK_WHITELIST/${host}/\"${host//(\'|\")/}\"}
+  fi
+done
+IFS=$IFS_ORG
+# surround with []
+RACK_ATTACK_WHITELIST="[${RACK_ATTACK_WHITELIST}]"
+if [[ "${RACK_ATTACK_WHITELIST}" != "${RACK_ATTACK_WHITELIST_ORIGIN}" ]]; then
+  printf "[warning] RACK_ATTACK_WHITELIST must be a yaml sequence of hosts.\nFixing from %s to %s\n" \
+    "${RACK_ATTACK_WHITELIST_ORIGIN}" \
+    "${RACK_ATTACK_WHITELIST}"
+fi
 RACK_ATTACK_MAXRETRY=${RACK_ATTACK_MAXRETRY:-10}
 RACK_ATTACK_FINDTIME=${RACK_ATTACK_FINDTIME:-60}
 RACK_ATTACK_BANTIME=${RACK_ATTACK_BANTIME:-3600}

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1068,6 +1068,24 @@ gitlab_configure_analytics() {
 
 gitlab_configure_rack_attack() {
   echo "Configuring gitlab::rack_attack..."
+
+  # validity check : RACK_ATTACK_WHITELIST should be an array of valid IP Address string
+  echo " Validating RACK_ATTACK_WHITELIST..."
+  /usr/bin/env ruby << SCRIPT
+  require 'ipaddr'
+  ${RACK_ATTACK_WHITELIST}.each do |host|
+    begin
+      printf("  input=%s, to_range=%s\n", host, IPAddr.new(host).to_range)
+    rescue IPAddr::InvalidAddressError => e
+      p e
+      exit 1
+    rescue => e
+      put "Unexpected error", e
+      exit 1
+    end
+  end
+SCRIPT
+
   update_template ${GITLAB_CONFIG} \
     RACK_ATTACK_ENABLED \
     RACK_ATTACK_WHITELIST \


### PR DESCRIPTION
close #2828

The current setup also accepts multiple hosts, but the syntax is a bit strange.  
The leading/trailing double quotes are embedded in the configuration file itself, so users should expect double quotes around the string they set. In other words, when setting two hosts 127.0.0.1 and 0.0.0.0/24, you will set the strings `127.0.0.1","0.0.0.0/24` in the environment variables. This is not intuitive.

This PR will:
- Change default value of configuration parameter `RACK_ATTACK_WHITELIST` from `127.0.0.1` to `["127.0.0.1"]`
- Remove double quote around corresponding config
- Add process for backward compatibility fallback to surround whole with [], each host with double quote
- Add whitelist validation process (an script written in ruby) that will be executed during configuration. This script will generate following output to docker log:
    ````
     Configuring gitlab::rack_attack...
     Validating RACK_ATTACK_WHITELIST...
      input=127.0.0.1, to_range=127.0.0.1..127.0.0.1
      input=0.0.0.0/24, to_range=0.0.0.0..0.0.0.255
    ````

Example docker-compose.yml
````yaml
services:
  gitlab:
    image: sameersbn/gitlab:latest
    environment:
    - RACK_ATTACK_WHITELIST='["127.0.0.1","0.0.0.0/24"]'
````