### PR TITLE
Remove ajv as an explicit dependency

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -203,7 +203,6 @@ chown ${GITLAB_USER}: ${GITLAB_INSTALL_DIR}/config/database.yml
 
 # Installs nodejs packages required to compile webpack
 exec_as_git yarn install --production --pure-lockfile
-exec_as_git yarn add ajv@^4.0.0
 
 echo "Compiling assets. Please be patient, this could take a while..."
 exec_as_git bundle exec rake gitlab:assets:compile USE_DB=false SKIP_STORAGE_VALIDATION=true NODE_OPTIONS="--max-old-space-size=4096"

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -2168,7 +2168,6 @@ migrate_database() {
       echo "Prepare recomplie assets... Installing missing node_modules for assets"
       chown -R ${GITLAB_USER}: ${GITLAB_HOME}/gitlab/node_modules
       exec_as_git yarn install --production --pure-lockfile
-      exec_as_git yarn add ajv@^4.0.0
       echo "Recompiling assets (relative_url in use), this could take a while..."
       exec_as_git bundle exec rake gitlab:assets:compile NODE_OPTIONS="--max-old-space-size=4096" >/dev/null 2>&1
     fi


### PR DESCRIPTION
Around v10.0.0 release, there was an issue so that we have to install `ajv` explicitly. This issue have been fixed on upstream, a few years ago.

It seems that fix MR on upstream is https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/14543 but we cannot check diff because source / target branch removed by mistake.

Anyway, no need to add ajv as an explicit dependency on (at least) gitlab v11 or later. We can revert the change.
This commit partially reverts 985d57afb9673b2f5acb1f12cbc13f230f6ec074 (pull request #1358)
