### PR TITLE
Add build patch to prevent rake task assets:compile to remove assets dir

### DIFF
--- a/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
+++ b/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/tasks/gitlab/assets.rake b/lib/tasks/gitlab/assets.rake
+index b8a6e7018767..5096d81ea63f 100644
+--- a/lib/tasks/gitlab/assets.rake
++++ b/lib/tasks/gitlab/assets.rake
+@@ -96,7 +96,14 @@ namespace :gitlab do
+       puts "Assets SHA256 for `HEAD`: #{Tasks::Gitlab::Assets.head_assets_sha256.inspect}"
+ 
+       if Tasks::Gitlab::Assets.head_assets_sha256 != Tasks::Gitlab::Assets.master_assets_sha256
+-        FileUtils.rm_rf([Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR] + Dir.glob('app/assets/javascripts/locale/**/app.js'))
++        # sameersbn/gitlab takes a cache of public_assets_dir by symlinking to volume to speedup relaunch (if relative url is used)
++        # so do not remove the directory directly, empty instead
++        # Dir.glob("*") ignores dotfiles (even it is fine to remove here), so list up children manually
++        removal_targets = Dir.glob('app/assets/javascripts/locale/**/app.js')
++        if Dir.exists?(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR)
++          removal_targets += Dir.children(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR).map {|child| File.join(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR, child)} 
++        end
++        FileUtils.rm_rf(removal_targets, secure: true)
+ 
+         # gettext:compile needs to run before rake:assets:precompile because
+         # app/assets/javascripts/locale/**/app.js are pre-compiled by Sprockets


### PR DESCRIPTION
Close #2866

GitLab does not launch after second run if relative url is used. This is caused by following upstream change to remove assets directory on assets compile. See https://gitlab.com/gitlab-org/gitlab/-/merge_requests/103715

First contained in v15.6.0 release

````sh
$ git -C ../gitlab.git/ tag --contains e46d92c0 | sort --version-sort | head -n 1
v15.6.0-ee
````

Issue backtrace:

1. `sameersbn/gitlab` create [symbolic link /home/git/gitlab/public/assets/ to point /home/git/data/tmp/assets if relative url is used](https://github.com/sameersbn/docker-gitlab/blob/8daea8cd172cee6fb61ea1c4eee84b08ac7f97fa/assets/runtime/functions#L1720-L1737). This is to store assets in the docker volume to avoid unnecessary recompilations. These assets are removed and recompiled [only when the gitlab version or relative url root is changed](https://github.com/sameersbn/docker-gitlab/blob/8daea8cd172cee6fb61ea1c4eee84b08ac7f97fa/assets/runtime/functions#L2159-L2179).
2. By the change provided by [gitlab.com/gitlab-org/gitlab!103715](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/103715), rake task `gitlab:assets:compile` became to remove assets directory directly (by `FileUtils.rm_rf()`). It does not remove compiled assets itself, but remove symlink /home/git/gitlab/public/assets . Then it compiles assets as usual. These assets will be stored in newly-created normal directory /home/git/gitlab/public/assets/
3. On container up, assets will be compiled if relative url root or version is changed.
4. On container down, whole container statement (except volumes) will be reset. These compiled assets will be removed as well because they are not in docker volume.
5. As we store [version number](https://github.com/sameersbn/docker-gitlab/blob/8daea8cd172cee6fb61ea1c4eee84b08ac7f97fa/assets/runtime/functions#L2155) and [relative url root path](https://github.com/sameersbn/docker-gitlab/blob/8daea8cd172cee6fb61ea1c4eee84b08ac7f97fa/assets/runtime/functions#L2178) to /home/git/data/tmp/, we cannot recognize we have to recompile assets (they are not modified, even assets themselves are removed).  
So we can say that it will launch successfully the first time, but will fail the next time.
6. reports ENOENT of assets - of course this is really happen because they are removed

To avoid the issue, this PR add a build time patch to change the behavior of rake task `gitlab:assets:compile` to empty assets directory instead of removing itself.