### PR TITLE
Backport to 16.7.x : Fix patch for assets compile

### DIFF
--- a/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
+++ b/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
@@ -12,7 +12,7 @@ index b8a6e7018767..5096d81ea63f 100644
 +        # Dir.glob("*") ignores dotfiles (even it is fine to remove here), so list up children manually
 +        removal_targets = Dir.glob('app/assets/javascripts/locale/**/app.js')
 +        if Dir.exist?(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR)
-+          removal_targets += Dir.children(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR).map {|child| File.join(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR, child)} 
++          removal_targets += Dir.children(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR).map {|child| File.join(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR, child)}
 +        end
 +        FileUtils.rm_rf(removal_targets, secure: true)
  

--- a/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
+++ b/assets/build/patches/0004-fix-raketask-gitlab-assets-compile.patch
@@ -11,7 +11,7 @@ index b8a6e7018767..5096d81ea63f 100644
 +        # so do not remove the directory directly, empty instead
 +        # Dir.glob("*") ignores dotfiles (even it is fine to remove here), so list up children manually
 +        removal_targets = Dir.glob('app/assets/javascripts/locale/**/app.js')
-+        if Dir.exists?(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR)
++        if Dir.exist?(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR)
 +          removal_targets += Dir.children(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR).map {|child| File.join(Tasks::Gitlab::Assets::PUBLIC_ASSETS_DIR, child)} 
 +        end
 +        FileUtils.rm_rf(removal_targets, secure: true)


### PR DESCRIPTION
This PR is backport of #2895 to 16.7.x branch.

This PR fixes a patch introduced by #2884.

- Replace removed ruby function in patch introduced by
https://github.com/sameersbn/docker-gitlab/pull/2884
It uses a function Dir.exists? that have been removed on Ruby 3.2 (see [release note](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) and [discussion on ruby issue tracker](https://bugs.ruby-lang.org/issues/17391)). This PR fixes the issue by simply replacing Dir.exists? to `Dir.exist?`. Building sameersbn/gitlab stops with error on compiling assets if we update Ruby to 3.2.x without this change.  
- Remove trailing whitespace in the patch
Just to reduce build warning.