### PR TITLE
Upgrade nodejs apt source repo from 18.x to 20.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex && \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
- && echo 'deb https://deb.nodesource.com/node_18.x focal main' > /etc/apt/sources.list.d/nodesource.list \
+ && echo 'deb https://deb.nodesource.com/node_20.x nodistro main' > /etc/apt/sources.list.d/nodesource.list \
  && wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add - \
  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
  && set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex && \
  && echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu focal main" >> /etc/apt/sources.list \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
- && wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add - \
  && echo 'deb https://deb.nodesource.com/node_20.x nodistro main' > /etc/apt/sources.list.d/nodesource.list \
  && wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg  | apt-key add - \
  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Required version is updated from v18.16.x to v20.13.x with GitLab v17.0.0 release.
This PR upgrade nodejs apt source repo from 18.x to 20.x. Currently nodejs 20.15.0 is installed.

Documentation:
- "Bump required Node.js version to 20 in installation guide"
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/154523

.tool-versions:
- "Update .tool-versions and .nvmrc to use nodejs v20.12.2"
  https://gitlab.com/gitlab-org/gitlab/-/merge_requests/149615

GitLab v17.0.0 or later requires (grants) nodejs v20.13.x or later, but nodejs v20.5.1 is installed for focal even later LTS are released.  
To avoid this issue, official installer script uses "nodistro" instead of specific distribution. So this PR also change apt source for nodjs from "focal" to "nodistro"  
See: https://github.com/nodesource/distributions/blob/83867e0fdde8ebb17f5f83644f00c4bb180a4568/scripts/deb/setup_20.x#L74

If we change the source repo to 20.x, GPG key also must be updated (if not, build fails with GPG error on installting nodejs).

----
Alternate design : replace nodejs installation to use nodesource script like below:
````sh
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - 
````
https://deb.nodesource.com/

Official documentation also do similar thing. See https://docs.gitlab.com/17.0/ee/install/installation.html#5-node