### PR TITLE
CI: bump jobs.release.executor to go/default:1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,12 +269,12 @@ jobs:
   release:
     executor:
       name: go/default
-      tag: '1.14'
+      tag: '1.22'
     steps:
       - checkout
       - run:
           name: Installing github-release tool
-          command: go get github.com/meterup/github-release
+          command: go install github.com/meterup/github-release@latest
       - run:
           name: Creating github release
           command: |


### PR DESCRIPTION
See #2962 for details.

Currently CI job `release` is failing on `go get github.com/meterup/github-release` because one of the dependencies uses a feature that will be introduced in a future version of go.  
See log: https://app.circleci.com/jobs/github/sameersbn/docker-gitlab/7095

This PR bumps go image version from 1.14 to 1.22 and update command to use `go install` instead of `go get`. As `go install` requires a version when current directory is not in amodule, this PR just use `@latest`. If we need to fix the behavior, we'd better to change it.