### PR TITLE
Create external-diffs directory if missing, closes #2965

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1665,6 +1665,11 @@ initialize_datadir() {
   chmod u+rwX ${GITLAB_SHARED_DIR}/ci_secure_files
   chown ${GITLAB_USER}: ${GITLAB_SHARED_DIR}/ci_secure_files
 
+  # create external-diffs dir
+  mkdir -p ${GITLAB_SHARED_DIR}/external-diffs
+  chmod u+rwX ${GITLAB_SHARED_DIR}/external-diffs
+  chown ${GITLAB_USER}: ${GITLAB_SHARED_DIR}/external-diffs
+
   # create artifacts dir
   mkdir -p ${GITLAB_ARTIFACTS_DIR}
   chmod u+rwX ${GITLAB_ARTIFACTS_DIR}


### PR DESCRIPTION
Tried to update the functions so the external-diffs folder is created when not present
and (automated) backups can proceed as normal.

@kkimurak , @sachilles I would pleased to get a review and will make any changes/improvements if necessary