### PR TITLE
Fix: script to configure feature flags cannot enable some flags

### DIFF
--- a/assets/runtime/scripts/configure_feature_flags.rb
+++ b/assets/runtime/scripts/configure_feature_flags.rb
@@ -21,7 +21,7 @@ class FeatureFlagCLI
       feature_flag_yamls.concat(Dir.glob("#{Gitlab.root}/ee/config/feature_flags/**/*.yml"))
     end if
 
-      list = feature_flag_yamls.map { |p| File.basename(p, File.extname(p)) }
+    list = feature_flag_yamls.map { |p| File.basename(p, File.extname(p)) }
     list
   end
 

--- a/assets/runtime/scripts/configure_feature_flags.rb
+++ b/assets/runtime/scripts/configure_feature_flags.rb
@@ -64,7 +64,7 @@ class FeatureFlagCLI
     if succeed
       available_flags = self.available_feature_flags
       disable_targets = available_flags & opts[:to_be_disabled]
-      enable_targets = available_flags & opts[:to_be_disabled]
+      enable_targets = available_flags & opts[:to_be_enabled]
 
       disable_targets.each do |feature|
         Feature.disable(feature)


### PR DESCRIPTION
I have implemented a script to control feature flags via environment variable in PR #2917 .

When generating the list of flags that would actually be enabled, the value specified in the option was ANDed with the list of flags that actually existed.  
At this time, I mistakenly performed a logical AND with the list of "flags ​to be disabled" specified in the option.  
This mistake caused a problem in which some flags could not be enabled. (I'm not sure why some flags can be enabled from this script even the scripts contains this mistake)

This PR fixes this to AND with the list of values ​​you want to enable.  
This PR also fix indent in script.