### PR TITLE
Docs: bump minimum required PostgreSQL to 14 (gitlab 17.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Please note furthermore, that only compatible versions of the `postgresql-client
 - `postgresql-client-14`,
 - and `postgresql-client-15`.
 
-*NOTE:* Version 13.7.0 and later requires PostgreSQL version 12.x. Version 16.0.0 and later requires PostgreSQL version 13.x
+*NOTE:* Version 13.7.0 and later requires PostgreSQL version 12.x. Version 16.0.0 and later requires PostgreSQL version 13.x. Version 17.0.0 and later requires PostgreSQL version 14.x.
 
 ##### External PostgreSQL Server
 
@@ -1866,7 +1866,7 @@ Sidekiq log format that will be used. Defaults to `json`
 
 ##### `DB_ADAPTER`
 
-The database type. Currently only postgresql is supported. Over 12.1 postgres force. Possible values: `postgresql`. Defaults to `postgresql`.
+The database type. Currently only postgresql is supported. Possible values: `postgresql`. Defaults to `postgresql`.
 
 ##### `DB_ENCODING`
 
@@ -2721,7 +2721,7 @@ Usage when using `docker-compose` can also be found there.
 >
 > If you're using `sameersbn/postgresql` then please upgrade to `sameersbn/postgresql:14-20230628` or later and add `DB_EXTENSION=pg_trgm,btree_gist` to the environment of the PostgreSQL container (see: <https://github.com/sameersbn/docker-gitlab/blob/master/docker-compose.yml#L21>).
 >
-> As of version 13.7.0, the required PostgreSQL is version 12.x. As of version 16.0.0, the required PostgreSQL is version 13.x. If you're using PostgreSQL image other than the above, please review section [Upgrading PostgreSQL](#upgrading-postgresql).
+> As of version 13.7.0, the required PostgreSQL is version 12.x. As of version 16.0.0, the required PostgreSQL is version 13.x. As of version 17.0.0, the required PostgreSQL is version 14.x. If you're using PostgreSQL image other than the above, please review section [Upgrading PostgreSQL](#upgrading-postgresql).
 
 GitLabHQ releases new versions on the 22nd of every month, bugfix releases immediately follow. I update this project almost immediately when a release is made (at least it has been the case so far). If you are using the image in production environments I recommend that you delay updates by a couple of days after the gitlab release, allowing some time for the dust to settle down.
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -41,8 +41,8 @@ Please note that this version does not yet include any rework as a consequence o
 Don't forget to consider the version specific upgrading instructions for [GitLab CE](https://docs.gitlab.com/ee/update/) **before** upgrading your GitLab CE instance!
 
 Please note:
-- GitLab 16.6.x requires at least PostgreSQL 13.
-- As of GitLab 16.7, PostgreSQL 14 is the default version. However, PostgreSQL 14 isn't supported on Geo deployments and is planned for future releases (see <https://docs.gitlab.com/ee/update/versions/gitlab_16_changes.html#1670>).
+- GitLab 17.x requires at least PostgreSQL 14.
+- See issues to be aware of when upgrading to 17.x : <https://docs.gitlab.com/ee/update/versions/gitlab_17_changes.html>
 
 ## Contributing
 


### PR DESCRIPTION
close #2994 

Add minimum requirement for GitLab 17.x or later: PostgreSQL 14.x.  
Also update the requirement note in release notes.