### PR TITLE
fix(#3010) Add symbolic link to the correct location of ca-cert file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ LABEL \
 
 EXPOSE 22/tcp 80/tcp 443/tcp
 
+RUN ln -s /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+
 VOLUME ["${GITLAB_DATA_DIR}", "${GITLAB_LOG_DIR}","${GITLAB_HOME}/gitlab/node_modules"]
 WORKDIR ${GITLAB_INSTALL_DIR}
 ENTRYPOINT ["/sbin/entrypoint.sh"]


### PR DESCRIPTION
A pull request including the fix for the #3010 issue as fixed in the PR #3016 but isolated to make it easier to merge.