### PR TITLE
Remove version from compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2807,8 +2807,6 @@ To do that you will need to set the environment variable `GITLAB_MONITORING_IP_W
 You can also set your `docker-compose.yml` [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck) configuration to make periodic checks:
 
 ```yml
-version: '2.3'
-
 services:
   gitlab:
     image: sameersbn/gitlab:18.0.1

--- a/contrib/docker-swarm/docker-compose.yml
+++ b/contrib/docker-swarm/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   redis:
     restart: always

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   redis:
     image: redis:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 
 services:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-
+---
 services:
   redis:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
----
+
 services:
   redis:
     restart: always

--- a/docs/docker-compose-keycloak.yml
+++ b/docs/docker-compose-keycloak.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   redis:
     restart: always

--- a/docs/docker-compose-registry.yml
+++ b/docs/docker-compose-registry.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   redis:
     restart: always

--- a/docs/s3_compatible_storage.md
+++ b/docs/s3_compatible_storage.md
@@ -65,8 +65,6 @@ Starting a fresh installation with GitLab would be like the `docker-compose` fil
 This is an example with minio.
 
 ```yml
-version: '2'
-
 services:
   redis:
     restart: always


### PR DESCRIPTION
This will prevent this message at every `docker compose SOMETHING`.
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion