### PR TITLE
Remove patch to remove HSTS setting from app/controller/application_controller.rb

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -178,9 +178,6 @@ rm -rf ${GITLAB_GITALY_BUILD_DIR}
 go clean --modcache
 rm -rf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-amd64.tar.gz ${GOROOT}
 
-# remove HSTS config from the default headers, we configure it in nginx
-exec_as_git sed -i "/headers\['Strict-Transport-Security'\]/d" ${GITLAB_INSTALL_DIR}/app/controllers/application_controller.rb
-
 # revert `rake gitlab:setup` changes from gitlabhq/gitlabhq@a54af831bae023770bf9b2633cc45ec0d5f5a66a
 exec_as_git sed -i 's/db:reset/db:setup/' ${GITLAB_INSTALL_DIR}/lib/tasks/gitlab/setup.rake
 


### PR DESCRIPTION
Fixed on upstream so no longer required
- gitlab-foss: https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/9341
  - commit [df376bad3c8586eccc0ee2da1590d14a66bdff10](https://gitlab.com/gitlab-org/gitlab-foss/-/commit/df376bad3c8586eccc0ee2da1590d14a66bdff10)
  - merge commit (squashed) : 9ec03807fd1ad2e0f04721abb7e29a044d5d0e75
- gitlab: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/1360
  - commit [76e96878aad0a281f8c32ef98a276b499e2581ad](https://gitlab.com/gitlab-org/gitlab/-/commit/76e96878aad0a281f8c32ef98a276b499e2581ad)

First contained tag:
- gitlab-foss: v9.0.0
- gitlab: v9.0.0-ee