### PR TITLE
Docs: fix RACK_ATTACK_WHITELIST section (quoting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2490,14 +2490,14 @@ Enable/disable rack middleware for blocking & throttling abusive requests Defaul
 
 Always allow requests from whitelisted host.
 This should be a valid yaml sequence of host address. Each host address string must be a valid IP address that can be passed to `IPAddr.new` of ruby. See [ruby-lang reference](https://docs.ruby-lang.org/en/3.0/IPAddr.html#method-c-new) for detail.
-If you need to set multiple hosts, set this parameter like `["1.1.1.1","192.168.0.0/24"]` for example. In docker-compose.yml, you have to quote whole value like below:
+If you need to set multiple hosts, set this parameter like `["1.1.1.1","192.168.0.0/24"]` for example.
 
 ````yaml
 environment:
-# pattern 1: surround with single quote, double quote each IP address
-- RACK_ATTACK_WHITELIST='["1.1.1.1","192.168.0.0/24"]'
-# pattern 2: surround with double quote, single quote each IP address
-- RACK_ATTACK_WHITELIST="['1.1.1.1','192.168.0.0/24']"
+# pattern 1: `- key=value` style : you can specify array of hosts as is
+- RACK_ATTACK_WHITELIST=["1.1.1.1","192.168.0.0/24"]
+# pattern 2: `key: value` style : you must surround with quote, as the value of environment variable must not be an array
+  RACK_ATTACK_WHITELIST: "['1.1.1.1','192.168.0.0/24']"
 ````
 
 Defaults to `["127.0.0.1"]`


### PR DESCRIPTION
This is a revision to the documentation introduced in #2846 (by me).  
In the original work, I required quoting when setting an array-like value in environment in docker-compose.yml, but if you use the syntax currently used by this repository's docker-compose.yml (`- key=value`), you must not quote whole values.

On the other hand, the yaml syntax accept `key: value` to list key and values. If you set an array-like value in this syntax, you must quote it because docker compose does not allow to set an array as the value of environment.

