### PR TITLE
docs: Fix required PostgreSQL version for GitLab 18.0.0 (was 18.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2732,7 +2732,7 @@ Usage when using `docker-compose` can also be found there.
 > - As of version 13.7.0, the required PostgreSQL version is 12.x.
 > - As of version 16.0.0, the required PostgreSQL version is 13.x.
 > - As of version 17.0.0, the required PostgreSQL version is 14.x.
-> - As of version 18.0.2, the required PostgreSQL version is 16.x.
+> - As of version 18.0.0, the required PostgreSQL version is 16.x.
 >
 > If you're using PostgreSQL image other than the above, please review section [Upgrading PostgreSQL](#upgrading-postgresql).
 


### PR DESCRIPTION
Updated the documentation to correctly reflect that GitLab 18.0.0 requires PostgreSQL 16.x, not 18.0.2 as previously stated.