### PR TITLE
Disable compiling sourcemaps to reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ENV GITLAB_VERSION=${VERSION} \
     GITLAB_LOG_DIR="/var/log/gitlab" \
     GITLAB_CACHE_DIR="/etc/docker-gitlab" \
     RAILS_ENV=production \
-    NODE_ENV=production
+    NODE_ENV=production \
+    NO_SOURCEMAPS=true
 
 ENV GITLAB_INSTALL_DIR="${GITLAB_HOME}/gitlab" \
     GITLAB_SHELL_INSTALL_DIR="${GITLAB_HOME}/gitlab-shell" \


### PR DESCRIPTION
This PR just adds image ENV `NO_SOURCEMAPS=true`.  

As I reported in #2860 (https://github.com/sameersbn/docker-gitlab/issues/2860#issuecomment-3012732268), we can set webpack configuration [`devtool`](https://webpack.js.org/configuration/devtool/) to `false` by setting environment variable [`NO_SOURCEMAP=true`](https://gitlab.com/gitlab-org/gitlab/-/blob/v18.1.2-ee/config/webpack.config.js#L952). This will significantly reduce the time taken by the rake task `gitlab:assets:compile`, which took up a large portion of the image build (total build time have been improved from 30min to 20min on my env).  

It also reduce image size : v18.1.2, 4.31GB -> 3.86GB.

In webpack documentation, it is recommended to set `devtool` to be disabled on production with maximum performance. 

> | devtool | performance | production | quality | comment
> | -- | -- | -- | -- | --
> | (none) | build: fastest<br>rebuild: fastest | yes | bundle | Recommended choice for production builds with maximum performance.

Official gitlab image `gitlab/gitlab-ce` and `gitlab/gitlab-ee` also does not ship with sourcemaps (see https://github.com/sameersbn/docker-gitlab/issues/2860#issuecomment-3056325680).  

Since I have not yet been able to verify how much each factor, such as CPU, memory, or disk I/O, affects the speed improvement, I would like to check the build time of this pull request to see how much the speed has improved in CI.