### PR TITLE
Remove `bundle install` for gitlab-shell

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -125,9 +125,6 @@ cd ${GITLAB_SHELL_INSTALL_DIR}
 exec_as_git cp -a config.yml.example config.yml
 
 echo "Compiling gitlab-shell golang executables..."
-exec_as_git bundle config set --local deployment 'true'
-exec_as_git bundle config set --local with 'development test'
-exec_as_git bundle install -j"$(nproc)"
 exec_as_git "PATH=$PATH" make verify setup
 
 # remove unused repositories directory created by gitlab-shell install


### PR DESCRIPTION
This PR simply removes `bundle install` for gitlab-shell intstallation step.  

In [official documentation](https://docs.gitlab.com/install/installation/#install-gitlab-shell), the installation step is described like below:

> ```sh
> # Run the installation task for gitlab-shell:
> sudo -u git -H bundle exec rake gitlab:shell:install RAILS_ENV=production
> ```

The rake task `gitlab:shell:install` is defined in [lib/task/gitlab/shell.rake](https://gitlab.com/gitlab-org/gitlab/-/blob/v18.1.2-ee/lib/tasks/gitlab/shell.rake#L32-38) and in v18.1.2 it just checkout repository, create necessary directories/configs and execute `make make_necessary_dirs build`. It is mostly similar to [current our setup](https://github.com/sameersbn/docker-gitlab/blob/b6eed6a079b5cc584f8c0768d3ab67a510fc8144/assets/build/install.sh#L131)(*) but rake task `gitlab:shell:install` does not execute `bundle install` as it is only needed for development/testing.
So, this PR simply remove the step. It will reduce build time a bit.  

Note: It was a workaround introduced by #2066 (v12.6.0, December 2019 - especially 2c3faa5) but seems to be no needed anymore. I have not yet been able to determine at this time when it became unnecessary.

----
(*) Official setup executes `make make_necessary_dirs build`. Task `build` will invoke `compile`, finally executes `go build` as defined task `bin/gitlab-shell` and `bin/gitlab-sshd`.

Our setup executes `make verify setup`. It will internally invoke these tasks:
- `verify_golang:` (`gofmt` for sources)
- `make_necessary_dirs` : exactly same
- `bin/gitlab-shell` (`bin:` -> `mkdir -p bin` and all commands (`go build ./cmd/...`))

Here is a link for Makefile I refered: https://gitlab.com/gitlab-org/gitlab-shell/-/blob/v14.43.0/Makefile

I'm not sure why official procedure specifies task `bin/gitlab-sshd` individually but I won't go into that further as it's off topic.