### PR TITLE
CI: update executor for job `release` to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
   release:
     executor:
       name: go/default
-      tag: '1.22'
+      tag: '1.24'
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Release job for sameersbn/gitlab 18.2.0 failing because "go installl meterup/github-release" fails as dependency (kevinburke/rest@v0.0.0) requires go >= 1.23.0).  
See https://github.com/sameersbn/docker-gitlab/pull/3140#issuecomment-3089792217 .

This PR simply update the version of go executor used in release job in CI.