### PR TITLE
Fix indentation of ps/wait block in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ case ${1} in
         migrate_database
         kill -15 $SUPERVISOR_PID
         if ps h -p $SUPERVISOR_PID > /dev/null ; then
-        wait $SUPERVISOR_PID || true
+          wait $SUPERVISOR_PID || true
         fi
         rm -rf /var/run/supervisor.sock
         configure_gitlab_requires_db


### PR DESCRIPTION
## Summary

Fixes the misleading indentation of the `ps`/`wait` block in `entrypoint.sh`. The `wait $SUPERVISOR_PID || true` line was indented at the same level as its enclosing `if`, which is confusing to readers and linters even though bash scopes the block via `then`/`fi`.

## Change

```diff
         if ps h -p $SUPERVISOR_PID > /dev/null ; then
-        wait $SUPERVISOR_PID || true
+          wait $SUPERVISOR_PID || true
         fi
```

No behavioral change — purely cosmetic alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)