### PR TITLE
Create agent plan content directory for backups

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1779,6 +1779,9 @@ initialize_datadir() {
   chmod u+rwX ${GITLAB_SHARED_DIR}/external-diffs
   chown ${GITLAB_USER}: ${GITLAB_SHARED_DIR}/external-diffs
 
+  # create agent plan content directory required by GitLab backup
+  install -d -o ${GITLAB_USER} -g ${GITLAB_USER} -m 0700 ${GITLAB_SHARED_DIR}/agent_plan_content
+
   # create artifacts dir
   mkdir -p ${GITLAB_ARTIFACTS_DIR}
   chmod u+rwX ${GITLAB_ARTIFACTS_DIR}


### PR DESCRIPTION
## What changed

Create `${GITLAB_SHARED_DIR}/agent_plan_content` during data-directory initialization with the expected `git:git` ownership and `0700` permissions.

## Why

GitLab backups from 19.1 can fail with `ENOENT` when the agent plan content directory has not been created yet. The directory is a configured backup path, but docker-gitlab does not currently initialize it.

This implements the working directory-creation workaround reported in #3269 as an idempotent container lifecycle step. The related upstream GitLab bug remains open: https://gitlab.com/gitlab-org/gitlab/-/work_items/604413

## Impact

Fresh and upgraded installations get the expected directory before a backup runs, avoiding a backup failure without requiring a manual workaround.

## Validation

- `bash -n assets/runtime/functions`
- `git diff --check`
- Executed the `install -d` command twice in a sameersbn GitLab container and verified directory type, `git:git` ownership, and mode `0700`

Fixes #3269
