### PR TITLE
Enable HSTS for GitLab Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1868,11 +1868,11 @@ Sets the bucket size for the server names hash tables. This is needed when you h
 
 ##### `NGINX_HSTS_ENABLED`
 
-Advanced configuration option for turning off the HSTS configuration. Applicable only when SSL is in use. Defaults to `true`. See [#138](https://github.com/sameersbn/docker-gitlab/issues/138) for use case scenario.
+Advanced configuration option for turning off HSTS for the GitLab and GitLab Pages nginx virtual hosts. Applicable only when SSL is in use. Defaults to `true`. See [#138](https://github.com/sameersbn/docker-gitlab/issues/138) for use case scenario.
 
 ##### `NGINX_HSTS_MAXAGE`
 
-Advanced configuration option for setting the HSTS max-age in the gitlab nginx vHost configuration. Applicable only when SSL is in use. Defaults to `31536000`.
+Advanced configuration option for setting the HSTS max-age in the GitLab and GitLab Pages nginx virtual hosts. Applicable only when SSL is in use. Defaults to `31536000`.
 
 ##### `NGINX_PROXY_BUFFERING`
 

--- a/README.md
+++ b/README.md
@@ -1870,11 +1870,11 @@ Sets the bucket size for the server names hash tables. This is needed when you h
 
 ##### `NGINX_HSTS_ENABLED`
 
-Advanced configuration option for turning off the HSTS configuration. Applicable only when SSL is in use. Defaults to `true`. See [#138](https://github.com/sameersbn/docker-gitlab/issues/138) for use case scenario.
+Advanced configuration option for turning off HSTS for the GitLab and GitLab Pages nginx virtual hosts. Applicable only when SSL is in use. Defaults to `true`. See [#138](https://github.com/sameersbn/docker-gitlab/issues/138) for use case scenario.
 
 ##### `NGINX_HSTS_MAXAGE`
 
-Advanced configuration option for setting the HSTS max-age in the gitlab nginx vHost configuration. Applicable only when SSL is in use. Defaults to `31536000`.
+Advanced configuration option for setting the HSTS max-age in the GitLab and GitLab Pages nginx virtual hosts. Applicable only when SSL is in use. Defaults to `31536000`.
 
 ##### `NGINX_PROXY_BUFFERING`
 

--- a/assets/runtime/config/nginx/gitlab-pages
+++ b/assets/runtime/config/nginx/gitlab-pages
@@ -9,6 +9,7 @@ server {
   ## Individual nginx logs for GitLab pages
   access_log  {{GITLAB_LOG_DIR}}/nginx/gitlab_pages_access.log;
   error_log   {{GITLAB_LOG_DIR}}/nginx/gitlab_pages_error.log;
+  add_header Strict-Transport-Security "max-age={{NGINX_HSTS_MAXAGE}}";
   location / {
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Real-IP           $remote_addr;

--- a/assets/runtime/config/nginx/gitlab-pages-ssl
+++ b/assets/runtime/config/nginx/gitlab-pages-ssl
@@ -30,6 +30,8 @@ server {
   server_name ~^.*{{GITLAB_PAGES_DOMAIN}};
   server_tokens off; ## Don't show the nginx version number, a security best practice
 
+  add_header Strict-Transport-Security "max-age={{NGINX_HSTS_MAXAGE}}";
+
   ## Strong SSL Security
   ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
   ssl_certificate {{SSL_PAGES_CERT_PATH}};

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1656,6 +1656,9 @@ nginx_configure_pages(){
   if [[ ${GITLAB_PAGES_ENABLED} == true ]]; then
     echo "Configuring nginx::gitlab-pages..."
     if [[ ${GITLAB_PAGES_NGINX_PROXY} == true ]]; then
+      if [[ ${GITLAB_PAGES_HTTPS} != true || ${NGINX_HSTS_ENABLED} != true ]]; then
+        sed -i "/{{NGINX_HSTS_MAXAGE}}/d" ${GITLAB_PAGES_NGINX_CONFIG}
+      fi
       if [[ ${GITLAB_PAGES_HTTPS} == true ]]; then
         update_template ${GITLAB_PAGES_NGINX_CONFIG} \
           GITLAB_PORT \
@@ -1668,6 +1671,7 @@ nginx_configure_pages(){
           SSL_PAGES_CIPHERS \
           SSL_PAGES_PROTOCOLS \
           SSL_DHPARAM_PATH \
+          NGINX_HSTS_MAXAGE \
           GITLAB_LOG_DIR
       else
         update_template ${GITLAB_PAGES_NGINX_CONFIG} \


### PR DESCRIPTION
## What changed

- Add the existing HSTS header template to both GitLab Pages nginx configurations.
- Render the configured `NGINX_HSTS_MAXAGE` when Pages HTTPS is enabled.
- Remove the header when Pages HTTPS or `NGINX_HSTS_ENABLED` is disabled.
- Clarify in the README that the existing HSTS options also apply to GitLab Pages.

## Why

The main GitLab nginx virtual host honors `NGINX_HSTS_ENABLED` and `NGINX_HSTS_MAXAGE`, but the Pages virtual hosts do not contain or configure the header. Changing those options therefore has no effect on Pages responses.

The non-TLS Pages template also needs the placeholder for deployments where TLS terminates at a load balancer while `GITLAB_PAGES_HTTPS=true`, matching the existing main GitLab virtual host behavior.

## Impact

GitLab Pages responses now use the same HSTS settings as the main GitLab virtual host, without adding new environment variables or changing the defaults.

## Validation

- `bash -n assets/runtime/functions`
- `git diff --check`
- Rendered and checked four cases: native Pages HTTPS, HSTS disabled, plain HTTP, and HTTPS terminated by a proxy

Fixes #2710
